### PR TITLE
Add support for collocated post-deploy errands

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -79,11 +79,12 @@ const (
 type OperationType string
 
 type OperationData struct {
-	BoshTaskID           int
-	BoshContextID        string `json:",omitempty"`
-	OperationType        OperationType
-	PlanID               string `json:",omitempty"`
-	PostDeployErrandName string `json:",omitempty"`
+	BoshTaskID                int
+	BoshContextID             string `json:",omitempty"`
+	OperationType             OperationType
+	PlanID                    string   `json:",omitempty"`
+	PostDeployErrandName      string   `json:",omitempty"`
+	PostDeployErrandInstances []string `json:",omitempty"`
 }
 
 const InstancePrefix = "service-instance_"
@@ -120,7 +121,7 @@ type BoshClient interface {
 	GetDeployments(logger *log.Logger) ([]boshdirector.Deployment, error)
 	DeleteDeployment(name, contextID string, logger *log.Logger) (int, error)
 	GetInfo(logger *log.Logger) (*boshdirector.Info, error)
-	RunErrand(deploymentName, errandName, contextID string, logger *log.Logger) (int, error)
+	RunErrand(deploymentName, errandName string, errandInstances []string, contextID string, logger *log.Logger) (int, error)
 	VerifyAuth(logger *log.Logger) error
 }
 

--- a/broker/broker_suite_test.go
+++ b/broker/broker_suite_test.go
@@ -113,7 +113,9 @@ var _ = BeforeEach(func() {
 	postDeployErrandPlan := config.Plan{
 		ID: postDeployErrandPlanID,
 		LifecycleErrands: &config.LifecycleErrands{
-			PostDeploy: "health-check",
+			PostDeploy: config.Errand{
+				Name: "health-check",
+			},
 		},
 		InstanceGroups: []serviceadapter.InstanceGroup{},
 	}

--- a/broker/deprovision.go
+++ b/broker/deprovision.go
@@ -123,6 +123,7 @@ func (b *Broker) runPreDeleteErrand(
 	taskID, err := b.boshClient.RunErrand(
 		deploymentName(instanceID),
 		preDeleteErrand,
+		[]string{},
 		boshContextID,
 		logger,
 	)

--- a/broker/deprovision_test.go
+++ b/broker/deprovision_test.go
@@ -172,7 +172,7 @@ var _ = Describe("deprovisioning instances", func() {
 
 		It("executes the specified errand", func() {
 			Expect(boshClient.RunErrandCallCount()).To(Equal(1))
-			argDeploymentName, argErrandName, contextID, _ := boshClient.RunErrandArgsForCall(0)
+			argDeploymentName, argErrandName, _, contextID, _ := boshClient.RunErrandArgsForCall(0)
 			Expect(argDeploymentName).To(Equal(broker.InstancePrefix + instanceID))
 			Expect(argErrandName).To(Equal("cleanup-resources"))
 			Expect(contextID).To(MatchRegexp(
@@ -187,7 +187,7 @@ var _ = Describe("deprovisioning instances", func() {
 		It("includes the operation type, task id, and context id in the operation data", func() {
 			var operationData broker.OperationData
 
-			_, _, contextID, _ := boshClient.RunErrandArgsForCall(0)
+			_, _, _, contextID, _ := boshClient.RunErrandArgsForCall(0)
 
 			Expect(json.Unmarshal([]byte(deprovisionSpec.OperationData), &operationData)).To(Succeed())
 			Expect(operationData).To(Equal(broker.OperationData{

--- a/broker/fakes/fake_bosh_client.go
+++ b/broker/fakes/fake_bosh_client.go
@@ -125,13 +125,14 @@ type FakeBoshClient struct {
 		result1 *boshdirector.Info
 		result2 error
 	}
-	RunErrandStub        func(deploymentName, errandName, contextID string, logger *log.Logger) (int, error)
+	RunErrandStub        func(deploymentName, errandName string, errandInstances []string, contextID string, logger *log.Logger) (int, error)
 	runErrandMutex       sync.RWMutex
 	runErrandArgsForCall []struct {
-		deploymentName string
-		errandName     string
-		contextID      string
-		logger         *log.Logger
+		deploymentName  string
+		errandName      string
+		errandInstances []string
+		contextID       string
+		logger          *log.Logger
 	}
 	runErrandReturns struct {
 		result1 int
@@ -575,19 +576,25 @@ func (fake *FakeBoshClient) GetInfoReturnsOnCall(i int, result1 *boshdirector.In
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) RunErrand(deploymentName string, errandName string, contextID string, logger *log.Logger) (int, error) {
+func (fake *FakeBoshClient) RunErrand(deploymentName string, errandName string, errandInstances []string, contextID string, logger *log.Logger) (int, error) {
+	var errandInstancesCopy []string
+	if errandInstances != nil {
+		errandInstancesCopy = make([]string, len(errandInstances))
+		copy(errandInstancesCopy, errandInstances)
+	}
 	fake.runErrandMutex.Lock()
 	ret, specificReturn := fake.runErrandReturnsOnCall[len(fake.runErrandArgsForCall)]
 	fake.runErrandArgsForCall = append(fake.runErrandArgsForCall, struct {
-		deploymentName string
-		errandName     string
-		contextID      string
-		logger         *log.Logger
-	}{deploymentName, errandName, contextID, logger})
-	fake.recordInvocation("RunErrand", []interface{}{deploymentName, errandName, contextID, logger})
+		deploymentName  string
+		errandName      string
+		errandInstances []string
+		contextID       string
+		logger          *log.Logger
+	}{deploymentName, errandName, errandInstancesCopy, contextID, logger})
+	fake.recordInvocation("RunErrand", []interface{}{deploymentName, errandName, errandInstancesCopy, contextID, logger})
 	fake.runErrandMutex.Unlock()
 	if fake.RunErrandStub != nil {
-		return fake.RunErrandStub(deploymentName, errandName, contextID, logger)
+		return fake.RunErrandStub(deploymentName, errandName, errandInstances, contextID, logger)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -601,10 +608,10 @@ func (fake *FakeBoshClient) RunErrandCallCount() int {
 	return len(fake.runErrandArgsForCall)
 }
 
-func (fake *FakeBoshClient) RunErrandArgsForCall(i int) (string, string, string, *log.Logger) {
+func (fake *FakeBoshClient) RunErrandArgsForCall(i int) (string, string, []string, string, *log.Logger) {
 	fake.runErrandMutex.RLock()
 	defer fake.runErrandMutex.RUnlock()
-	return fake.runErrandArgsForCall[i].deploymentName, fake.runErrandArgsForCall[i].errandName, fake.runErrandArgsForCall[i].contextID, fake.runErrandArgsForCall[i].logger
+	return fake.runErrandArgsForCall[i].deploymentName, fake.runErrandArgsForCall[i].errandName, fake.runErrandArgsForCall[i].errandInstances, fake.runErrandArgsForCall[i].contextID, fake.runErrandArgsForCall[i].logger
 }
 
 func (fake *FakeBoshClient) RunErrandReturns(result1 int, result2 error) {

--- a/broker/lifecycle_runner.go
+++ b/broker/lifecycle_runner.go
@@ -75,7 +75,7 @@ func (l LifeCycleRunner) processPostDeployment(
 		}
 
 		if errand := operationData.PostDeployErrandName; errand != "" {
-			return l.runErrand(deploymentName, errand, operationData.BoshContextID, logger)
+			return l.runErrand(deploymentName, errand, operationData.PostDeployErrandInstances, operationData.BoshContextID, logger)
 		}
 
 		if operationData.PlanID == "" {
@@ -126,8 +126,8 @@ func (l LifeCycleRunner) processPreDelete(
 	}
 }
 
-func (l LifeCycleRunner) runErrand(deploymentName, errand, contextID string, log *log.Logger) (boshdirector.BoshTask, error) {
-	taskID, err := l.boshClient.RunErrand(deploymentName, errand, contextID, log)
+func (l LifeCycleRunner) runErrand(deploymentName, errand string, errandInstances []string, contextID string, log *log.Logger) (boshdirector.BoshTask, error) {
+	taskID, err := l.boshClient.RunErrand(deploymentName, errand, errandInstances, contextID, log)
 	if err != nil {
 		return boshdirector.BoshTask{}, err
 	}
@@ -152,5 +152,5 @@ func (l LifeCycleRunner) runErrandFromConfig(task boshdirector.BoshTask, deploym
 		return task, nil
 	}
 
-	return l.runErrand(deploymentName, errand, operationData.BoshContextID, logger)
+	return l.runErrand(deploymentName, errand, plan.PostDeployErrandInstances(), operationData.BoshContextID, logger)
 }

--- a/broker/lifecycle_runner_test.go
+++ b/broker/lifecycle_runner_test.go
@@ -35,14 +35,18 @@ var _ = Describe("Lifecycle runner", func() {
 		config.Plan{
 			ID: planID,
 			LifecycleErrands: &config.LifecycleErrands{
-				PostDeploy: errand1,
-				PostDeployInstances: errandInstances,
+				PostDeploy: config.Errand{
+					Name:      errand1,
+					Instances: errandInstances,
+				},
 			},
 		},
 		config.Plan{
 			ID: anotherPlanID,
 			LifecycleErrands: &config.LifecycleErrands{
-				PostDeploy: errand2,
+				PostDeploy: config.Errand{
+					Name: errand2,
+				},
 			},
 		},
 		config.Plan{
@@ -140,9 +144,9 @@ var _ = Describe("Lifecycle runner", func() {
 						var err error
 						deployRunner = broker.NewLifeCycleRunner(boshClient, plans)
 						operationData = broker.OperationData{
-							BoshContextID:        contextID,
-							OperationType:        broker.OperationTypeCreate,
-							PostDeployErrandName: errand1,
+							BoshContextID:             contextID,
+							OperationType:             broker.OperationTypeCreate,
+							PostDeployErrandName:      errand1,
 							PostDeployErrandInstances: errandInstances,
 						}
 

--- a/broker/provision.go
+++ b/broker/provision.go
@@ -125,9 +125,11 @@ func (b *Broker) provisionInstance(ctx context.Context, instanceID string, planI
 
 	var boshContextID string
 	var operationPostDeployErrand string
+	var operationPostDeployErrandInstances []string
 	if plan.PostDeployErrand() != "" {
 		boshContextID = uuid.New()
 		operationPostDeployErrand = plan.PostDeployErrand()
+		operationPostDeployErrandInstances = plan.PostDeployErrandInstances()
 	}
 
 	boshTaskID, manifest, err := b.deployer.Create(deploymentName(instanceID), plan.ID, requestParams, boshContextID, logger)
@@ -152,10 +154,11 @@ func (b *Broker) provisionInstance(ctx context.Context, instanceID string, planI
 	}
 
 	operationData := OperationData{
-		BoshTaskID:           boshTaskID,
-		OperationType:        OperationTypeCreate,
-		BoshContextID:        boshContextID,
-		PostDeployErrandName: operationPostDeployErrand,
+		BoshTaskID:                boshTaskID,
+		OperationType:             OperationTypeCreate,
+		BoshContextID:             boshContextID,
+		PostDeployErrandName:      operationPostDeployErrand,
+		PostDeployErrandInstances: operationPostDeployErrandInstances,
 	}
 
 	//Dashboard url optional

--- a/broker/provision_test.go
+++ b/broker/provision_test.go
@@ -236,8 +236,10 @@ var _ = Describe("provisioning", func() {
 			postDeployErrandPlan := config.Plan{
 				ID: planID,
 				LifecycleErrands: &config.LifecycleErrands{
-					PostDeploy:          errandName,
-					PostDeployInstances: []string{errandInstance},
+					PostDeploy: config.Errand{
+						Name:      errandName,
+						Instances: []string{errandInstance},
+					},
 				},
 				InstanceGroups: []sdk.InstanceGroup{
 					{

--- a/broker/provision_test.go
+++ b/broker/provision_test.go
@@ -26,8 +26,9 @@ import (
 
 var _ = Describe("provisioning", func() {
 	var (
-		planID     string
-		errandName string
+		planID         string
+		errandName     string
+		errandInstance string
 
 		serviceSpec  brokerapi.ProvisionedServiceSpec
 		provisionErr error
@@ -230,11 +231,13 @@ var _ = Describe("provisioning", func() {
 		BeforeEach(func() {
 			planID = "post-deploy-errand-plan-id"
 			errandName = "health-check"
+			errandInstance = "post-deploy-instance-group-name/0"
 
 			postDeployErrandPlan := config.Plan{
 				ID: planID,
 				LifecycleErrands: &config.LifecycleErrands{
-					PostDeploy: errandName,
+					PostDeploy:          errandName,
+					PostDeployInstances: []string{errandInstance},
 				},
 				InstanceGroups: []sdk.InstanceGroup{
 					{
@@ -261,6 +264,7 @@ var _ = Describe("provisioning", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(data.BoshContextID).NotTo(BeEmpty())
 			Expect(data.PostDeployErrandName).To(Equal(errandName))
+			Expect(data.PostDeployErrandInstances).To(Equal([]string{errandInstance}))
 		})
 
 		It("calls the deployer with a bosh context id", func() {

--- a/broker/startup_checks_test.go
+++ b/broker/startup_checks_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Initializing the broker", func() {
 			emptyLifecycleErrandsPlan := config.Plan{
 				ID: "empty-lifecycle-errands-plan-id",
 				LifecycleErrands: &config.LifecycleErrands{
-					PostDeploy: "",
+					PostDeploy: config.Errand{},
 					PreDelete:  "",
 				},
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -327,7 +327,7 @@ func (s ServiceOffering) FindPlanByID(id string) (Plan, bool) {
 func (s ServiceOffering) HasLifecycleErrands() bool {
 	for _, plan := range s.Plans {
 		if plan.LifecycleErrands != nil {
-			if plan.LifecycleErrands.PostDeploy != "" || plan.LifecycleErrands.PreDelete != "" {
+			if plan.LifecycleErrands.PostDeploy.Name != "" || plan.LifecycleErrands.PreDelete != "" {
 				return true
 			}
 		}
@@ -339,7 +339,7 @@ func (s ServiceOffering) HasLifecycleErrands() bool {
 func (s ServiceOffering) Validate() error {
 	for _, plan := range s.Plans {
 		if plan.LifecycleErrands != nil {
-			for _, instanceName := range plan.LifecycleErrands.PostDeployInstances {
+			for _, instanceName := range plan.LifecycleErrands.PostDeploy.Instances {
 				pieces := strings.Split(instanceName, "/")
 				if len(pieces) != 1 && len(pieces) != 2 {
 					return fmt.Errorf("Must specify pool or instance '%s' in format 'name' or 'name/id-or-index'", instanceName)
@@ -410,14 +410,14 @@ func (p Plan) PostDeployErrand() string {
 		return ""
 	}
 
-	return p.LifecycleErrands.PostDeploy
+	return p.LifecycleErrands.PostDeploy.Name
 }
 func (p Plan) PostDeployErrandInstances() []string {
 	if p.LifecycleErrands == nil {
 		return nil
 	}
 
-	return p.LifecycleErrands.PostDeployInstances
+	return p.LifecycleErrands.PostDeploy.Instances
 }
 
 func (p Plan) PreDeleteErrand() string {
@@ -429,9 +429,13 @@ func (p Plan) PreDeleteErrand() string {
 }
 
 type LifecycleErrands struct {
-	PostDeploy          string   `yaml:"post_deploy"`
-	PostDeployInstances []string `yaml:"post_deploy_instances,omitempty"`
-	PreDelete           string   `yaml:"pre_delete"`
+	PostDeploy Errand `yaml:"post_deploy"`
+	PreDelete  string `yaml:"pre_delete"`
+}
+
+type Errand struct {
+	Name      string   `yaml:"name"`
+	Instances []string `yaml:"instances"`
 }
 
 type PlanMetadata struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,7 +129,8 @@ var _ = Describe("Config", func() {
 									"persistence": true,
 								},
 								LifecycleErrands: &config.LifecycleErrands{
-									PostDeploy: "health-check",
+									PostDeploy:          "health-check",
+									PostDeployInstances: []string{"redis-errand/0", "redis-errand/1"},
 								},
 								InstanceGroups: []serviceadapter.InstanceGroup{
 									{
@@ -150,7 +151,7 @@ var _ = Describe("Config", func() {
 									{
 										Name:         "redis-errand",
 										VMType:       "some-vm-3",
-										Instances:    1,
+										Instances:    2,
 										Networks:     []string{"net5", "net6"},
 										Lifecycle:    "errand",
 										VMExtensions: []string{},
@@ -391,6 +392,36 @@ var _ = Describe("Config", func() {
 
 			It("parses free as false", func() {
 				Expect(*conf.ServiceCatalog.Plans[0].Free).To(BeFalse())
+			})
+		})
+
+		Context("when the post deploy errand instances property is specified as a/b/c", func() {
+			BeforeEach(func() {
+				configFileName = "config_with_invalid_post_deploy_instances.yml"
+			})
+
+			It("returns an error", func() {
+				Expect(parseErr).To(MatchError(MatchRegexp("Must specify pool or instance '.*' in format 'name' or 'name/id-or-index'")))
+			})
+		})
+
+		Context("when the post deploy errand instances property is specified as /b", func() {
+			BeforeEach(func() {
+				configFileName = "config_with_invalid_post_deploy_instances_1.yml"
+			})
+
+			It("returns an error", func() {
+				Expect(parseErr).To(MatchError(MatchRegexp("Must specify pool or instance '.*' in format 'name' or 'name/id-or-index'")))
+			})
+		})
+
+		Context("when the post deploy errand instances property is specified as a/", func() {
+			BeforeEach(func() {
+				configFileName = "config_with_invalid_post_deploy_instances_2.yml"
+			})
+
+			It("returns an error", func() {
+				Expect(parseErr).To(MatchError(MatchRegexp("Must specify pool or instance '.*' in format 'name' or 'name/id-or-index'")))
 			})
 		})
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -129,8 +129,10 @@ var _ = Describe("Config", func() {
 									"persistence": true,
 								},
 								LifecycleErrands: &config.LifecycleErrands{
-									PostDeploy:          "health-check",
-									PostDeployInstances: []string{"redis-errand/0", "redis-errand/1"},
+									PostDeploy: config.Errand{
+										Name:      "health-check",
+										Instances: []string{"redis-errand/0", "redis-errand/1"},
+									},
 								},
 								InstanceGroups: []serviceadapter.InstanceGroup{
 									{

--- a/config/test_assets/config_with_invalid_post_deploy_instances.yml
+++ b/config/test_assets/config_with_invalid_post_deploy_instances.yml
@@ -90,8 +90,9 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
-        post_deploy_instances: [some/invalid/instance]
+        post_deploy:
+          name: health-check
+          instances: [some/invalid/instance]
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/config_with_invalid_post_deploy_instances.yml
+++ b/config/test_assets/config_with_invalid_post_deploy_instances.yml
@@ -91,7 +91,7 @@ service_catalog:
         persistence: true
       lifecycle_errands:
         post_deploy: health-check
-        post_deploy_instances: [redis-errand/0, redis-errand/1]
+        post_deploy_instances: [some/invalid/instance]
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/config_with_invalid_post_deploy_instances_1.yml
+++ b/config/test_assets/config_with_invalid_post_deploy_instances_1.yml
@@ -90,8 +90,9 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
-        post_deploy_instances: [/invalid]
+        post_deploy:
+          name: health-check
+          instances: [/invalid]
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/config_with_invalid_post_deploy_instances_1.yml
+++ b/config/test_assets/config_with_invalid_post_deploy_instances_1.yml
@@ -91,7 +91,7 @@ service_catalog:
         persistence: true
       lifecycle_errands:
         post_deploy: health-check
-        post_deploy_instances: [redis-errand/0, redis-errand/1]
+        post_deploy_instances: [/invalid]
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/config_with_invalid_post_deploy_instances_2.yml
+++ b/config/test_assets/config_with_invalid_post_deploy_instances_2.yml
@@ -90,8 +90,9 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
-        post_deploy_instances: [some/invalid/]
+        post_deploy:
+          name: health-check
+          instances: [some/invalid/]
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/config_with_invalid_post_deploy_instances_2.yml
+++ b/config/test_assets/config_with_invalid_post_deploy_instances_2.yml
@@ -91,7 +91,7 @@ service_catalog:
         persistence: true
       lifecycle_errands:
         post_deploy: health-check
-        post_deploy_instances: [redis-errand/0, redis-errand/1]
+        post_deploy_instances: [some/invalid/]
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/good_config.yml
+++ b/config/test_assets/good_config.yml
@@ -90,8 +90,9 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
-        post_deploy_instances: [redis-errand/0, redis-errand/1]
+        post_deploy:
+          name: health-check
+          instances: [redis-errand/0, redis-errand/1]
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/service_deployment_with_latest_release.yml
+++ b/config/test_assets/service_deployment_with_latest_release.yml
@@ -92,7 +92,8 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
+        post_deploy:
+          name: health-check
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/service_deployment_with_latest_stemcell.yml
+++ b/config/test_assets/service_deployment_with_latest_stemcell.yml
@@ -89,7 +89,8 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
+        post_deploy:
+          name: health-check
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/service_deployment_with_n_latest_release.yml
+++ b/config/test_assets/service_deployment_with_n_latest_release.yml
@@ -89,7 +89,8 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
+        post_deploy:
+          name: health-check
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/config/test_assets/service_deployment_with_n_latest_stemcell.yml
+++ b/config/test_assets/service_deployment_with_n_latest_stemcell.yml
@@ -89,7 +89,8 @@ service_catalog:
       properties:
         persistence: true
       lifecycle_errands:
-        post_deploy: health-check
+        post_deploy:
+          name: health-check
       instance_groups:
         - name: redis-server
           vm_type: some-vm

--- a/integration_tests/on_demand_service_broker/deprovision_test.go
+++ b/integration_tests/on_demand_service_broker/deprovision_test.go
@@ -159,7 +159,7 @@ var _ = Describe("deprovisioning service instances", func() {
 					boshDirector.VerifyAndMock(
 						mockbosh.GetDeployment(deploymentName(instanceID)).RespondsWithRawManifest([]byte(`a: b`)),
 						mockbosh.Tasks(deploymentName(instanceID)).RespondsWithNoTasks(),
-						mockbosh.Errand(deploymentName(instanceID), errandName).
+						mockbosh.Errand(deploymentName(instanceID), errandName, `{}`).
 							WithAnyContextID().RedirectsToTask(boshErrandTaskID),
 					)
 

--- a/integration_tests/on_demand_service_broker/integration_tests_suite_test.go
+++ b/integration_tests/on_demand_service_broker/integration_tests_suite_test.go
@@ -284,7 +284,7 @@ func provisionInstanceWithAsyncFlag(instanceID, planID string, arbitraryParams m
 
 func lastOperationForInstance(instanceID string, operationData broker.OperationData) *http.Response {
 	lastOperationURL := fmt.Sprintf("http://localhost:%d/v2/service_instances/%s/last_operation", brokerPort, instanceID)
-	if operationData != (broker.OperationData{}) {
+	if operationData.PlanID != "" {
 		operationDataBytes, err := json.Marshal(operationData)
 		Expect(err).NotTo(HaveOccurred())
 		lastOperationURL = fmt.Sprintf("%s?operation=%s", lastOperationURL, url.QueryEscape(string(operationDataBytes)))

--- a/integration_tests/on_demand_service_broker/last_operation_test.go
+++ b/integration_tests/on_demand_service_broker/last_operation_test.go
@@ -296,7 +296,7 @@ var _ = Describe("last operation", func() {
 					mockbosh.TasksByContext(deploymentName(instanceID), contextID).
 						RespondsOKWithJSON(boshdirector.BoshTasks{taskDone}),
 					mockbosh.TaskOutput(taskDone.ID).RespondsOKWith(""),
-					mockbosh.Errand(deploymentName(instanceID), errandName).
+					mockbosh.Errand(deploymentName(instanceID), errandName, `{}`).
 						WithContextID(contextID).RedirectsToTask(taskProcessing.ID),
 					mockbosh.Task(taskProcessing.ID).RespondsOKWithJSON(taskProcessing),
 				)
@@ -853,7 +853,7 @@ var _ = Describe("last operation", func() {
 					mockbosh.TasksByContext(deploymentName(instanceID), contextID).
 						RespondsWithATask(taskDone),
 					mockbosh.TaskOutput(taskDone.ID).RespondsOKWith(""),
-					mockbosh.Errand(deploymentName(instanceID), postDeployErrandName).
+					mockbosh.Errand(deploymentName(instanceID), postDeployErrandName, `{}`).
 						WithContextID(contextID).RedirectsToTask(taskProcessing.ID),
 					mockbosh.Task(taskProcessing.ID).RespondsOKWithJSON(taskProcessing),
 				)

--- a/integration_tests/on_demand_service_broker/last_operation_test.go
+++ b/integration_tests/on_demand_service_broker/last_operation_test.go
@@ -251,7 +251,9 @@ var _ = Describe("last operation", func() {
 				ID:   planID,
 				Name: "post-deploy-plan",
 				LifecycleErrands: &config.LifecycleErrands{
-					PostDeploy: errandName,
+					PostDeploy: config.Errand{
+						Name: errandName,
+					},
 				},
 			}
 
@@ -788,7 +790,9 @@ var _ = Describe("last operation", func() {
 				ID:   planID,
 				Name: "post-deploy-plan",
 				LifecycleErrands: &config.LifecycleErrands{
-					PostDeploy: "health-check",
+					PostDeploy: config.Errand{
+						Name: "health-check",
+					},
 				},
 			}
 

--- a/integration_tests/on_demand_service_broker/management_test.go
+++ b/integration_tests/on_demand_service_broker/management_test.go
@@ -395,7 +395,9 @@ var _ = Describe("Management API", func() {
 						},
 					},
 					LifecycleErrands: &config.LifecycleErrands{
-						PostDeploy: postDeployErrandName,
+						PostDeploy: config.Errand{
+							Name: postDeployErrandName,
+						},
 					},
 				}
 

--- a/integration_tests/on_demand_service_broker/provision_test.go
+++ b/integration_tests/on_demand_service_broker/provision_test.go
@@ -389,7 +389,8 @@ var _ = Describe("provision service instance", func() {
 					},
 				},
 				LifecycleErrands: &config.LifecycleErrands{
-					PostDeploy: "health-check",
+					PostDeploy:          "health-check",
+					PostDeployInstances: []string{"health-check-instance/0", "health-check-instance/1"},
 				},
 			}
 			conf.ServiceCatalog.Plans = config.Plans{postDeployErrandPlan}
@@ -429,6 +430,8 @@ var _ = Describe("provision service instance", func() {
 			Expect(operationData.BoshContextID).NotTo(BeEmpty())
 			By("including the post deploy errand name")
 			Expect(operationData.PostDeployErrandName).To(Equal("health-check"))
+			By("including the post deploy errand instances")
+			Expect(operationData.PostDeployErrandInstances).To(Equal([]string{"health-check-instance/0", "health-check-instance/1"}))
 		})
 	})
 

--- a/integration_tests/on_demand_service_broker/provision_test.go
+++ b/integration_tests/on_demand_service_broker/provision_test.go
@@ -389,8 +389,10 @@ var _ = Describe("provision service instance", func() {
 					},
 				},
 				LifecycleErrands: &config.LifecycleErrands{
-					PostDeploy:          "health-check",
-					PostDeployInstances: []string{"health-check-instance/0", "health-check-instance/1"},
+					PostDeploy: config.Errand{
+						Name:      "health-check",
+						Instances: []string{"health-check-instance/0", "health-check-instance/1"},
+					},
 				},
 			}
 			conf.ServiceCatalog.Plans = config.Plans{postDeployErrandPlan}

--- a/integration_tests/on_demand_service_broker/startup_test.go
+++ b/integration_tests/on_demand_service_broker/startup_test.go
@@ -394,7 +394,9 @@ var _ = Describe("Startup", func() {
 							},
 						},
 						LifecycleErrands: &config.LifecycleErrands{
-							PostDeploy: "health-check",
+							PostDeploy: config.Errand{
+								Name: "health-check",
+							},
 						},
 					}
 
@@ -449,7 +451,9 @@ var _ = Describe("Startup", func() {
 							},
 						},
 						LifecycleErrands: &config.LifecycleErrands{
-							PostDeploy: "health-check",
+							PostDeploy: config.Errand{
+								Name: "health-check",
+							},
 						},
 					}
 
@@ -507,7 +511,9 @@ var _ = Describe("Startup", func() {
 							},
 						},
 						LifecycleErrands: &config.LifecycleErrands{
-							PostDeploy: "health-check",
+							PostDeploy: config.Errand{
+								Name: "health-check",
+							},
 						},
 					}
 

--- a/integration_tests/on_demand_service_broker/update_test.go
+++ b/integration_tests/on_demand_service_broker/update_test.go
@@ -213,7 +213,9 @@ var _ = Describe("updating a service instance", func() {
 						},
 					},
 					LifecycleErrands: &config.LifecycleErrands{
-						PostDeploy: "health-check",
+						PostDeploy: config.Errand{
+							Name: "health-check",
+						},
 					},
 				}
 				conf.ServiceCatalog.Plans = append(conf.ServiceCatalog.Plans, postDeployErrandPlan)
@@ -262,7 +264,9 @@ var _ = Describe("updating a service instance", func() {
 						},
 					},
 					LifecycleErrands: &config.LifecycleErrands{
-						PostDeploy: "health-check",
+						PostDeploy: config.Errand{
+							Name: "health-check",
+						},
 					},
 				}
 				conf.ServiceCatalog.Plans = append(conf.ServiceCatalog.Plans, postDeployErrandPlan)
@@ -491,7 +495,9 @@ var _ = Describe("updating a service instance", func() {
 						},
 					},
 					LifecycleErrands: &config.LifecycleErrands{
-						PostDeploy: "health-check",
+						PostDeploy: config.Errand{
+							Name: "health-check",
+						},
 					},
 				}
 				conf.ServiceCatalog.Plans = config.Plans{postDeployErrandPlan}

--- a/mockhttp/mockbosh/errand.go
+++ b/mockhttp/mockbosh/errand.go
@@ -16,12 +16,12 @@ type errandMock struct {
 	*mockhttp.Handler
 }
 
-func Errand(deploymentName, errandName string) *errandMock {
+func Errand(deploymentName, errandName, body string) *errandMock {
 	mock := errandMock{
 		Handler: mockhttp.NewMockedHttpRequest("POST", fmt.Sprintf("/deployments/%s/errands/%s/runs", deploymentName, errandName)),
 	}
 	mock.WithContentType("application/json")
-	mock.WithBody("{}")
+	mock.WithJSONBody(body)
 	return &mock
 }
 


### PR DESCRIPTION
post_deploy yml declaration changed from:
```
post_deploy: errand_name
```
to

```
post_deploy:
  name: errand_name
  instances: [instance_name/0]
```

[#151676136]

@avade @mfine30 @tylerphelan 