### PR TITLE
Suggested update for pending change error message

### DIFF
--- a/broker/errors.go
+++ b/broker/errors.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	GenericErrorPrefix         = "There was a problem completing your request. Please contact your operations team providing the following information:"
-	PendingChangesErrorMessage = "The service broker has been updated, and this service instance is out of date. Please contact your operator."
+	PendingChangesErrorMessage = "Regenerated manifest differs from original. The service broker may have been updated since this service instance was provisioned. Please contact your operator."
 	OperationInProgressMessage = "An operation is in progress for your service instance. Please try again later."
 
 	UpdateLoggerAction = ""


### PR DESCRIPTION
We had a difficult time debugging a problem that generated this message
and hope the new message will make things easier for those who follow.

Signed-off-by: Alton Fong <altonf@vmware.com>

What we had seen was that a service instance was provisioned, but when trying to issue an update operation (resize the service instance), the generated manifest from the service adapter differed. We had not updated the service broker between operations, and so were confused by that error message.