### PR TITLE
Add support for BOSH Configs

### DIFF
--- a/boshdirector/delete_config.go
+++ b/boshdirector/delete_config.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cloudfoundry/bosh-cli/director"
+	"github.com/pkg/errors"
+)
+
+func (c *Client) DeleteConfig(configType, configName string, logger *log.Logger) (bool, error) {
+	logger.Printf("deleting %s config %s\n", configType, configName)
+	d, err := c.Director(director.NewNoopTaskReporter())
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to build director")
+	}
+	found, err := d.DeleteConfig(configType, configName)
+	if err != nil {
+		return false, errors.Wrap(err, fmt.Sprintf(`BOSH error deleting "%s" config "%s"`, configType, configName))
+	}
+
+	return found, nil
+}

--- a/boshdirector/delete_config_test.go
+++ b/boshdirector/delete_config_test.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("deleting bosh config", func() {
+	var (
+		configType      = "some-config-type"
+		configName      = "some-config-name"
+		configFound     bool
+		deleteConfigErr error
+	)
+
+	Describe("DeleteConfig", func() {
+		It("returns true when the config exists", func() {
+			fakeDirector.DeleteConfigReturns(true, nil)
+			configFound, deleteConfigErr = c.DeleteConfig(configType, configName, logger)
+
+			Expect(configFound).To(BeTrue())
+			Expect(deleteConfigErr).NotTo(HaveOccurred())
+		})
+
+		It("returns false when the config does not exists", func() {
+			fakeDirector.DeleteConfigReturns(false, nil)
+			configFound, deleteConfigErr = c.DeleteConfig(configType, configName, logger)
+
+			Expect(configFound).To(BeFalse())
+			Expect(deleteConfigErr).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when the client cannot delete the config", func() {
+			fakeDirector.DeleteConfigReturns(false, errors.New("oops"))
+			configFound, deleteConfigErr = c.DeleteConfig(configType, configName, logger)
+
+			Expect(configFound).To(BeFalse())
+			Expect(deleteConfigErr).To(MatchError(ContainSubstring(`BOSH error deleting "some-config-type" config "some-config-name"`)))
+		})
+	})
+})

--- a/boshdirector/get_configs.go
+++ b/boshdirector/get_configs.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cloudfoundry/bosh-cli/director"
+	"github.com/pkg/errors"
+)
+
+const (
+	boshConfigsLimit = 30
+)
+
+func (c *Client) GetConfigs(configName string, logger *log.Logger) ([]BoshConfig, error) {
+	var configs []BoshConfig
+
+	logger.Printf("getting configs for %s\n", configName)
+	d, err := c.Director(director.NewNoopTaskReporter())
+	if err != nil {
+		return configs, errors.Wrap(err, "Failed to build director")
+	}
+
+	boshConfigs, err := d.ListConfigs(boshConfigsLimit, director.ConfigsFilter{Name: configName})
+	if err != nil {
+		return configs, errors.Wrap(err, fmt.Sprintf(`BOSH error getting configs for "%s"`, configName))
+	}
+
+	for _, config := range boshConfigs {
+		configs = append(configs, BoshConfig{Type: config.Type, Name: config.Name, Content: config.Content})
+	}
+	return configs, nil
+}

--- a/boshdirector/get_configs_test.go
+++ b/boshdirector/get_configs_test.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector_test
+
+import (
+	"errors"
+
+	"github.com/cloudfoundry/bosh-cli/director"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/pivotal-cf/on-demand-service-broker/boshdirector"
+)
+
+var _ = Describe("getting bosh configs", func() {
+	var (
+		configType      = "some-config-type"
+		configName      = "some-config-name"
+		configContent   = "some-config-content"
+		directorConfigs []director.Config
+		boshConfigs     []BoshConfig
+		listConfigsErr  error
+	)
+
+	BeforeEach(func() {
+		directorConfigs = []director.Config{
+			director.Config{
+				ID:      "some-config-id",
+				Type:    configType,
+				Name:    configName,
+				Content: configContent,
+				Team:    "some-config-team",
+			},
+		}
+	})
+
+	Describe("GetConfigs", func() {
+		It("returns the bosh configs", func() {
+			fakeDirector.ListConfigsReturns(directorConfigs, nil)
+			boshConfigs, listConfigsErr = c.GetConfigs(configName, logger)
+
+			Expect(boshConfigs).To(Equal([]BoshConfig{
+				BoshConfig{
+					Type:    configType,
+					Name:    configName,
+					Content: configContent,
+				},
+			}))
+			Expect(listConfigsErr).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when the client cannot list configs", func() {
+			fakeDirector.ListConfigsReturns([]director.Config{}, errors.New("oops"))
+			boshConfigs, listConfigsErr = c.GetConfigs(configName, logger)
+
+			Expect(listConfigsErr).To(MatchError(ContainSubstring(`BOSH error getting configs for "some-config-name"`)))
+		})
+	})
+})

--- a/boshdirector/latest_config.go
+++ b/boshdirector/latest_config.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cloudfoundry/bosh-cli/director"
+	"github.com/pkg/errors"
+)
+
+func (c *Client) LatestConfig(configType, configName string, logger *log.Logger) (BoshConfig, error) {
+	logger.Printf("getting latest %s config %s\n", configType, configName)
+	d, err := c.Director(director.NewNoopTaskReporter())
+	if err != nil {
+		return BoshConfig{}, errors.Wrap(err, "Failed to build director")
+	}
+	config, err := d.LatestConfig(configType, configName)
+	if err != nil {
+		return BoshConfig{}, errors.Wrap(err, fmt.Sprintf(`BOSH error getting latest "%s" config "%s"`, configType, configName))
+	}
+
+	return BoshConfig{
+		Name:    config.Name,
+		Type:    config.Type,
+		Content: config.Content,
+	}, nil
+}
+
+type BoshConfig struct {
+	Type    string
+	Name    string
+	Content string
+}

--- a/boshdirector/latest_config_test.go
+++ b/boshdirector/latest_config_test.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector_test
+
+import (
+	"errors"
+
+	"github.com/cloudfoundry/bosh-cli/director"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/pivotal-cf/on-demand-service-broker/boshdirector"
+)
+
+var _ = Describe("getting latest bosh config", func() {
+	var (
+		configType      = "some-config-type"
+		configName      = "some-config-name"
+		configContent   = "some-config-content"
+		directorConfig  director.Config
+		boshConfig      BoshConfig
+		latestConfigErr error
+	)
+
+	BeforeEach(func() {
+		directorConfig = director.Config{
+			ID:      "some-config-id",
+			Type:    configType,
+			Name:    configName,
+			Content: configContent,
+			Team:    "some-config-team",
+		}
+	})
+
+	Describe("LatestConfig", func() {
+		It("returns the bosh config when the latest config exists", func() {
+			fakeDirector.LatestConfigReturns(directorConfig, nil)
+			boshConfig, latestConfigErr = c.LatestConfig(configType, configName, logger)
+
+			Expect(boshConfig).To(Equal(BoshConfig{
+				Type:    configType,
+				Name:    configName,
+				Content: configContent,
+			},
+			))
+			Expect(latestConfigErr).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when the client cannot get the latest config", func() {
+			fakeDirector.LatestConfigReturns(director.Config{}, errors.New("oops"))
+			boshConfig, latestConfigErr = c.LatestConfig(configType, configName, logger)
+
+			Expect(latestConfigErr).To(MatchError(ContainSubstring(`BOSH error getting latest "some-config-type" config "some-config-name"`)))
+		})
+	})
+})

--- a/boshdirector/update_config.go
+++ b/boshdirector/update_config.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/cloudfoundry/bosh-cli/director"
+	"github.com/pkg/errors"
+)
+
+func (c *Client) UpdateConfig(configType, configName string, configContent []byte, logger *log.Logger) error {
+	logger.Printf("updating %s config %s\n", configType, configName)
+	d, err := c.Director(director.NewNoopTaskReporter())
+	if err != nil {
+		return errors.Wrap(err, "Failed to build director")
+	}
+	if _, err := d.UpdateConfig(configType, configName, configContent); err != nil {
+		return errors.Wrap(err, fmt.Sprintf(`BOSH error updating "%s" config "%s"`, configType, configName))
+	}
+
+	return nil
+}

--- a/boshdirector/update_config_test.go
+++ b/boshdirector/update_config_test.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2018-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package boshdirector_test
+
+import (
+	"errors"
+
+	"github.com/cloudfoundry/bosh-cli/director"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("updating bosh config", func() {
+	var (
+		configType      = "some-config-type"
+		configName      = "some-config-name"
+		configContent   = "some-config-content"
+		updateConfigErr error
+	)
+
+	Describe("UpdateConfig", func() {
+		It("returns the bosh config when the latest config exists", func() {
+			fakeDirector.UpdateConfigReturns(director.Config{}, nil)
+			updateConfigErr = c.UpdateConfig(configType, configName, []byte(configContent), logger)
+
+			Expect(updateConfigErr).NotTo(HaveOccurred())
+		})
+
+		It("returns an error when the client cannot get the latest config", func() {
+			fakeDirector.UpdateConfigReturns(director.Config{}, errors.New("oops"))
+			updateConfigErr = c.UpdateConfig(configType, configName, []byte(configContent), logger)
+
+			Expect(updateConfigErr).To(MatchError(ContainSubstring(`BOSH error updating "some-config-type" config "some-config-name"`)))
+		})
+	})
+})

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -194,6 +194,9 @@ type BoshClient interface {
 	GetDNSAddresses(deploymentName string, requestedDNS []config.BindingDNS) (map[string]string, error)
 	Deploy(manifest []byte, contextID string, logger *log.Logger, reporter *boshdirector.AsyncTaskReporter) (int, error)
 	Recreate(deploymentName, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error)
+	GetConfigs(configName string, logger *log.Logger) ([]boshdirector.BoshConfig, error)
+	DeleteConfig(configType, configName string, logger *log.Logger) (bool, error)
+	UpdateConfig(configType, configName string, configContent []byte, logger *log.Logger) error
 }
 
 //go:generate counterfeiter -o fakes/fake_cloud_foundry_client.go . CloudFoundryClient

--- a/broker/fakes/fake_bosh_client.go
+++ b/broker/fakes/fake_bosh_client.go
@@ -2,78 +2,96 @@
 package fakes
 
 import (
-	"log"
-	"sync"
+	log "log"
+	sync "sync"
 
-	"github.com/pivotal-cf/on-demand-service-broker/boshdirector"
-	"github.com/pivotal-cf/on-demand-service-broker/broker"
-	"github.com/pivotal-cf/on-demand-service-broker/config"
-	"github.com/pivotal-cf/on-demand-services-sdk/bosh"
+	boshdirector "github.com/pivotal-cf/on-demand-service-broker/boshdirector"
+	broker "github.com/pivotal-cf/on-demand-service-broker/broker"
+	config "github.com/pivotal-cf/on-demand-service-broker/config"
+	bosh "github.com/pivotal-cf/on-demand-services-sdk/bosh"
 )
 
 type FakeBoshClient struct {
-	GetTaskStub        func(taskID int, logger *log.Logger) (boshdirector.BoshTask, error)
-	getTaskMutex       sync.RWMutex
-	getTaskArgsForCall []struct {
-		taskID int
-		logger *log.Logger
+	DeleteConfigStub        func(string, string, *log.Logger) (bool, error)
+	deleteConfigMutex       sync.RWMutex
+	deleteConfigArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
 	}
-	getTaskReturns struct {
-		result1 boshdirector.BoshTask
+	deleteConfigReturns struct {
+		result1 bool
 		result2 error
 	}
-	getTaskReturnsOnCall map[int]struct {
-		result1 boshdirector.BoshTask
+	deleteConfigReturnsOnCall map[int]struct {
+		result1 bool
 		result2 error
 	}
-	GetTasksStub        func(deploymentName string, logger *log.Logger) (boshdirector.BoshTasks, error)
-	getTasksMutex       sync.RWMutex
-	getTasksArgsForCall []struct {
-		deploymentName string
-		logger         *log.Logger
+	DeleteDeploymentStub        func(string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)
+	deleteDeploymentMutex       sync.RWMutex
+	deleteDeploymentArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
 	}
-	getTasksReturns struct {
-		result1 boshdirector.BoshTasks
+	deleteDeploymentReturns struct {
+		result1 int
 		result2 error
 	}
-	getTasksReturnsOnCall map[int]struct {
-		result1 boshdirector.BoshTasks
+	deleteDeploymentReturnsOnCall map[int]struct {
+		result1 int
 		result2 error
 	}
-	GetNormalisedTasksByContextStub        func(deploymentName, contextID string, logger *log.Logger) (boshdirector.BoshTasks, error)
-	getNormalisedTasksByContextMutex       sync.RWMutex
-	getNormalisedTasksByContextArgsForCall []struct {
-		deploymentName string
-		contextID      string
-		logger         *log.Logger
+	DeployStub        func([]byte, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)
+	deployMutex       sync.RWMutex
+	deployArgsForCall []struct {
+		arg1 []byte
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
 	}
-	getNormalisedTasksByContextReturns struct {
-		result1 boshdirector.BoshTasks
+	deployReturns struct {
+		result1 int
 		result2 error
 	}
-	getNormalisedTasksByContextReturnsOnCall map[int]struct {
-		result1 boshdirector.BoshTasks
+	deployReturnsOnCall map[int]struct {
+		result1 int
 		result2 error
 	}
-	VMsStub        func(deploymentName string, logger *log.Logger) (bosh.BoshVMs, error)
-	vMsMutex       sync.RWMutex
-	vMsArgsForCall []struct {
-		deploymentName string
-		logger         *log.Logger
+	GetConfigsStub        func(string, *log.Logger) ([]boshdirector.BoshConfig, error)
+	getConfigsMutex       sync.RWMutex
+	getConfigsArgsForCall []struct {
+		arg1 string
+		arg2 *log.Logger
 	}
-	vMsReturns struct {
-		result1 bosh.BoshVMs
+	getConfigsReturns struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}
-	vMsReturnsOnCall map[int]struct {
-		result1 bosh.BoshVMs
+	getConfigsReturnsOnCall map[int]struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}
-	GetDeploymentStub        func(name string, logger *log.Logger) ([]byte, bool, error)
+	GetDNSAddressesStub        func(string, []config.BindingDNS) (map[string]string, error)
+	getDNSAddressesMutex       sync.RWMutex
+	getDNSAddressesArgsForCall []struct {
+		arg1 string
+		arg2 []config.BindingDNS
+	}
+	getDNSAddressesReturns struct {
+		result1 map[string]string
+		result2 error
+	}
+	getDNSAddressesReturnsOnCall map[int]struct {
+		result1 map[string]string
+		result2 error
+	}
+	GetDeploymentStub        func(string, *log.Logger) ([]byte, bool, error)
 	getDeploymentMutex       sync.RWMutex
 	getDeploymentArgsForCall []struct {
-		name   string
-		logger *log.Logger
+		arg1 string
+		arg2 *log.Logger
 	}
 	getDeploymentReturns struct {
 		result1 []byte
@@ -85,10 +103,10 @@ type FakeBoshClient struct {
 		result2 bool
 		result3 error
 	}
-	GetDeploymentsStub        func(logger *log.Logger) ([]boshdirector.Deployment, error)
+	GetDeploymentsStub        func(*log.Logger) ([]boshdirector.Deployment, error)
 	getDeploymentsMutex       sync.RWMutex
 	getDeploymentsArgsForCall []struct {
-		logger *log.Logger
+		arg1 *log.Logger
 	}
 	getDeploymentsReturns struct {
 		result1 []boshdirector.Deployment
@@ -98,26 +116,10 @@ type FakeBoshClient struct {
 		result1 []boshdirector.Deployment
 		result2 error
 	}
-	DeleteDeploymentStub        func(name, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error)
-	deleteDeploymentMutex       sync.RWMutex
-	deleteDeploymentArgsForCall []struct {
-		name         string
-		contextID    string
-		logger       *log.Logger
-		taskReporter *boshdirector.AsyncTaskReporter
-	}
-	deleteDeploymentReturns struct {
-		result1 int
-		result2 error
-	}
-	deleteDeploymentReturnsOnCall map[int]struct {
-		result1 int
-		result2 error
-	}
-	GetInfoStub        func(logger *log.Logger) (boshdirector.Info, error)
+	GetInfoStub        func(*log.Logger) (boshdirector.Info, error)
 	getInfoMutex       sync.RWMutex
 	getInfoArgsForCall []struct {
-		logger *log.Logger
+		arg1 *log.Logger
 	}
 	getInfoReturns struct {
 		result1 boshdirector.Info
@@ -127,86 +129,56 @@ type FakeBoshClient struct {
 		result1 boshdirector.Info
 		result2 error
 	}
-	RunErrandStub        func(deploymentName, errandName string, errandInstances []string, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error)
-	runErrandMutex       sync.RWMutex
-	runErrandArgsForCall []struct {
-		deploymentName  string
-		errandName      string
-		errandInstances []string
-		contextID       string
-		logger          *log.Logger
-		taskReporter    *boshdirector.AsyncTaskReporter
+	GetNormalisedTasksByContextStub        func(string, string, *log.Logger) (boshdirector.BoshTasks, error)
+	getNormalisedTasksByContextMutex       sync.RWMutex
+	getNormalisedTasksByContextArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
 	}
-	runErrandReturns struct {
-		result1 int
+	getNormalisedTasksByContextReturns struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}
-	runErrandReturnsOnCall map[int]struct {
-		result1 int
+	getNormalisedTasksByContextReturnsOnCall map[int]struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}
-	VariablesStub        func(deploymentName string, logger *log.Logger) ([]boshdirector.Variable, error)
-	variablesMutex       sync.RWMutex
-	variablesArgsForCall []struct {
-		deploymentName string
-		logger         *log.Logger
+	GetTaskStub        func(int, *log.Logger) (boshdirector.BoshTask, error)
+	getTaskMutex       sync.RWMutex
+	getTaskArgsForCall []struct {
+		arg1 int
+		arg2 *log.Logger
 	}
-	variablesReturns struct {
-		result1 []boshdirector.Variable
+	getTaskReturns struct {
+		result1 boshdirector.BoshTask
 		result2 error
 	}
-	variablesReturnsOnCall map[int]struct {
-		result1 []boshdirector.Variable
+	getTaskReturnsOnCall map[int]struct {
+		result1 boshdirector.BoshTask
 		result2 error
 	}
-	VerifyAuthStub        func(logger *log.Logger) error
-	verifyAuthMutex       sync.RWMutex
-	verifyAuthArgsForCall []struct {
-		logger *log.Logger
+	GetTasksStub        func(string, *log.Logger) (boshdirector.BoshTasks, error)
+	getTasksMutex       sync.RWMutex
+	getTasksArgsForCall []struct {
+		arg1 string
+		arg2 *log.Logger
 	}
-	verifyAuthReturns struct {
-		result1 error
-	}
-	verifyAuthReturnsOnCall map[int]struct {
-		result1 error
-	}
-	GetDNSAddressesStub        func(deploymentName string, requestedDNS []config.BindingDNS) (map[string]string, error)
-	getDNSAddressesMutex       sync.RWMutex
-	getDNSAddressesArgsForCall []struct {
-		deploymentName string
-		requestedDNS   []config.BindingDNS
-	}
-	getDNSAddressesReturns struct {
-		result1 map[string]string
+	getTasksReturns struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}
-	getDNSAddressesReturnsOnCall map[int]struct {
-		result1 map[string]string
+	getTasksReturnsOnCall map[int]struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}
-	DeployStub        func(manifest []byte, contextID string, logger *log.Logger, reporter *boshdirector.AsyncTaskReporter) (int, error)
-	deployMutex       sync.RWMutex
-	deployArgsForCall []struct {
-		manifest  []byte
-		contextID string
-		logger    *log.Logger
-		reporter  *boshdirector.AsyncTaskReporter
-	}
-	deployReturns struct {
-		result1 int
-		result2 error
-	}
-	deployReturnsOnCall map[int]struct {
-		result1 int
-		result2 error
-	}
-	RecreateStub        func(deploymentName, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error)
+	RecreateStub        func(string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)
 	recreateMutex       sync.RWMutex
 	recreateArgsForCall []struct {
-		deploymentName string
-		contextID      string
-		logger         *log.Logger
-		taskReporter   *boshdirector.AsyncTaskReporter
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
 	}
 	recreateReturns struct {
 		result1 int
@@ -216,235 +188,433 @@ type FakeBoshClient struct {
 		result1 int
 		result2 error
 	}
+	RunErrandStub        func(string, string, []string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)
+	runErrandMutex       sync.RWMutex
+	runErrandArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 []string
+		arg4 string
+		arg5 *log.Logger
+		arg6 *boshdirector.AsyncTaskReporter
+	}
+	runErrandReturns struct {
+		result1 int
+		result2 error
+	}
+	runErrandReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
+	UpdateConfigStub        func(string, string, []byte, *log.Logger) error
+	updateConfigMutex       sync.RWMutex
+	updateConfigArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 []byte
+		arg4 *log.Logger
+	}
+	updateConfigReturns struct {
+		result1 error
+	}
+	updateConfigReturnsOnCall map[int]struct {
+		result1 error
+	}
+	VMsStub        func(string, *log.Logger) (bosh.BoshVMs, error)
+	vMsMutex       sync.RWMutex
+	vMsArgsForCall []struct {
+		arg1 string
+		arg2 *log.Logger
+	}
+	vMsReturns struct {
+		result1 bosh.BoshVMs
+		result2 error
+	}
+	vMsReturnsOnCall map[int]struct {
+		result1 bosh.BoshVMs
+		result2 error
+	}
+	VariablesStub        func(string, *log.Logger) ([]boshdirector.Variable, error)
+	variablesMutex       sync.RWMutex
+	variablesArgsForCall []struct {
+		arg1 string
+		arg2 *log.Logger
+	}
+	variablesReturns struct {
+		result1 []boshdirector.Variable
+		result2 error
+	}
+	variablesReturnsOnCall map[int]struct {
+		result1 []boshdirector.Variable
+		result2 error
+	}
+	VerifyAuthStub        func(*log.Logger) error
+	verifyAuthMutex       sync.RWMutex
+	verifyAuthArgsForCall []struct {
+		arg1 *log.Logger
+	}
+	verifyAuthReturns struct {
+		result1 error
+	}
+	verifyAuthReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBoshClient) GetTask(taskID int, logger *log.Logger) (boshdirector.BoshTask, error) {
-	fake.getTaskMutex.Lock()
-	ret, specificReturn := fake.getTaskReturnsOnCall[len(fake.getTaskArgsForCall)]
-	fake.getTaskArgsForCall = append(fake.getTaskArgsForCall, struct {
-		taskID int
-		logger *log.Logger
-	}{taskID, logger})
-	fake.recordInvocation("GetTask", []interface{}{taskID, logger})
-	fake.getTaskMutex.Unlock()
-	if fake.GetTaskStub != nil {
-		return fake.GetTaskStub(taskID, logger)
+func (fake *FakeBoshClient) DeleteConfig(arg1 string, arg2 string, arg3 *log.Logger) (bool, error) {
+	fake.deleteConfigMutex.Lock()
+	ret, specificReturn := fake.deleteConfigReturnsOnCall[len(fake.deleteConfigArgsForCall)]
+	fake.deleteConfigArgsForCall = append(fake.deleteConfigArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("DeleteConfig", []interface{}{arg1, arg2, arg3})
+	fake.deleteConfigMutex.Unlock()
+	if fake.DeleteConfigStub != nil {
+		return fake.DeleteConfigStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getTaskReturns.result1, fake.getTaskReturns.result2
+	fakeReturns := fake.deleteConfigReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) GetTaskCallCount() int {
-	fake.getTaskMutex.RLock()
-	defer fake.getTaskMutex.RUnlock()
-	return len(fake.getTaskArgsForCall)
+func (fake *FakeBoshClient) DeleteConfigCallCount() int {
+	fake.deleteConfigMutex.RLock()
+	defer fake.deleteConfigMutex.RUnlock()
+	return len(fake.deleteConfigArgsForCall)
 }
 
-func (fake *FakeBoshClient) GetTaskArgsForCall(i int) (int, *log.Logger) {
-	fake.getTaskMutex.RLock()
-	defer fake.getTaskMutex.RUnlock()
-	return fake.getTaskArgsForCall[i].taskID, fake.getTaskArgsForCall[i].logger
+func (fake *FakeBoshClient) DeleteConfigCalls(stub func(string, string, *log.Logger) (bool, error)) {
+	fake.deleteConfigMutex.Lock()
+	defer fake.deleteConfigMutex.Unlock()
+	fake.DeleteConfigStub = stub
 }
 
-func (fake *FakeBoshClient) GetTaskReturns(result1 boshdirector.BoshTask, result2 error) {
-	fake.GetTaskStub = nil
-	fake.getTaskReturns = struct {
-		result1 boshdirector.BoshTask
+func (fake *FakeBoshClient) DeleteConfigArgsForCall(i int) (string, string, *log.Logger) {
+	fake.deleteConfigMutex.RLock()
+	defer fake.deleteConfigMutex.RUnlock()
+	argsForCall := fake.deleteConfigArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeBoshClient) DeleteConfigReturns(result1 bool, result2 error) {
+	fake.deleteConfigMutex.Lock()
+	defer fake.deleteConfigMutex.Unlock()
+	fake.DeleteConfigStub = nil
+	fake.deleteConfigReturns = struct {
+		result1 bool
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetTaskReturnsOnCall(i int, result1 boshdirector.BoshTask, result2 error) {
-	fake.GetTaskStub = nil
-	if fake.getTaskReturnsOnCall == nil {
-		fake.getTaskReturnsOnCall = make(map[int]struct {
-			result1 boshdirector.BoshTask
+func (fake *FakeBoshClient) DeleteConfigReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.deleteConfigMutex.Lock()
+	defer fake.deleteConfigMutex.Unlock()
+	fake.DeleteConfigStub = nil
+	if fake.deleteConfigReturnsOnCall == nil {
+		fake.deleteConfigReturnsOnCall = make(map[int]struct {
+			result1 bool
 			result2 error
 		})
 	}
-	fake.getTaskReturnsOnCall[i] = struct {
-		result1 boshdirector.BoshTask
+	fake.deleteConfigReturnsOnCall[i] = struct {
+		result1 bool
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetTasks(deploymentName string, logger *log.Logger) (boshdirector.BoshTasks, error) {
-	fake.getTasksMutex.Lock()
-	ret, specificReturn := fake.getTasksReturnsOnCall[len(fake.getTasksArgsForCall)]
-	fake.getTasksArgsForCall = append(fake.getTasksArgsForCall, struct {
-		deploymentName string
-		logger         *log.Logger
-	}{deploymentName, logger})
-	fake.recordInvocation("GetTasks", []interface{}{deploymentName, logger})
-	fake.getTasksMutex.Unlock()
-	if fake.GetTasksStub != nil {
-		return fake.GetTasksStub(deploymentName, logger)
+func (fake *FakeBoshClient) DeleteDeployment(arg1 string, arg2 string, arg3 *log.Logger, arg4 *boshdirector.AsyncTaskReporter) (int, error) {
+	fake.deleteDeploymentMutex.Lock()
+	ret, specificReturn := fake.deleteDeploymentReturnsOnCall[len(fake.deleteDeploymentArgsForCall)]
+	fake.deleteDeploymentArgsForCall = append(fake.deleteDeploymentArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("DeleteDeployment", []interface{}{arg1, arg2, arg3, arg4})
+	fake.deleteDeploymentMutex.Unlock()
+	if fake.DeleteDeploymentStub != nil {
+		return fake.DeleteDeploymentStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getTasksReturns.result1, fake.getTasksReturns.result2
+	fakeReturns := fake.deleteDeploymentReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) GetTasksCallCount() int {
-	fake.getTasksMutex.RLock()
-	defer fake.getTasksMutex.RUnlock()
-	return len(fake.getTasksArgsForCall)
+func (fake *FakeBoshClient) DeleteDeploymentCallCount() int {
+	fake.deleteDeploymentMutex.RLock()
+	defer fake.deleteDeploymentMutex.RUnlock()
+	return len(fake.deleteDeploymentArgsForCall)
 }
 
-func (fake *FakeBoshClient) GetTasksArgsForCall(i int) (string, *log.Logger) {
-	fake.getTasksMutex.RLock()
-	defer fake.getTasksMutex.RUnlock()
-	return fake.getTasksArgsForCall[i].deploymentName, fake.getTasksArgsForCall[i].logger
+func (fake *FakeBoshClient) DeleteDeploymentCalls(stub func(string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)) {
+	fake.deleteDeploymentMutex.Lock()
+	defer fake.deleteDeploymentMutex.Unlock()
+	fake.DeleteDeploymentStub = stub
 }
 
-func (fake *FakeBoshClient) GetTasksReturns(result1 boshdirector.BoshTasks, result2 error) {
-	fake.GetTasksStub = nil
-	fake.getTasksReturns = struct {
-		result1 boshdirector.BoshTasks
+func (fake *FakeBoshClient) DeleteDeploymentArgsForCall(i int) (string, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
+	fake.deleteDeploymentMutex.RLock()
+	defer fake.deleteDeploymentMutex.RUnlock()
+	argsForCall := fake.deleteDeploymentArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeBoshClient) DeleteDeploymentReturns(result1 int, result2 error) {
+	fake.deleteDeploymentMutex.Lock()
+	defer fake.deleteDeploymentMutex.Unlock()
+	fake.DeleteDeploymentStub = nil
+	fake.deleteDeploymentReturns = struct {
+		result1 int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetTasksReturnsOnCall(i int, result1 boshdirector.BoshTasks, result2 error) {
-	fake.GetTasksStub = nil
-	if fake.getTasksReturnsOnCall == nil {
-		fake.getTasksReturnsOnCall = make(map[int]struct {
-			result1 boshdirector.BoshTasks
+func (fake *FakeBoshClient) DeleteDeploymentReturnsOnCall(i int, result1 int, result2 error) {
+	fake.deleteDeploymentMutex.Lock()
+	defer fake.deleteDeploymentMutex.Unlock()
+	fake.DeleteDeploymentStub = nil
+	if fake.deleteDeploymentReturnsOnCall == nil {
+		fake.deleteDeploymentReturnsOnCall = make(map[int]struct {
+			result1 int
 			result2 error
 		})
 	}
-	fake.getTasksReturnsOnCall[i] = struct {
-		result1 boshdirector.BoshTasks
+	fake.deleteDeploymentReturnsOnCall[i] = struct {
+		result1 int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetNormalisedTasksByContext(deploymentName string, contextID string, logger *log.Logger) (boshdirector.BoshTasks, error) {
-	fake.getNormalisedTasksByContextMutex.Lock()
-	ret, specificReturn := fake.getNormalisedTasksByContextReturnsOnCall[len(fake.getNormalisedTasksByContextArgsForCall)]
-	fake.getNormalisedTasksByContextArgsForCall = append(fake.getNormalisedTasksByContextArgsForCall, struct {
-		deploymentName string
-		contextID      string
-		logger         *log.Logger
-	}{deploymentName, contextID, logger})
-	fake.recordInvocation("GetNormalisedTasksByContext", []interface{}{deploymentName, contextID, logger})
-	fake.getNormalisedTasksByContextMutex.Unlock()
-	if fake.GetNormalisedTasksByContextStub != nil {
-		return fake.GetNormalisedTasksByContextStub(deploymentName, contextID, logger)
+func (fake *FakeBoshClient) Deploy(arg1 []byte, arg2 string, arg3 *log.Logger, arg4 *boshdirector.AsyncTaskReporter) (int, error) {
+	var arg1Copy []byte
+	if arg1 != nil {
+		arg1Copy = make([]byte, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.deployMutex.Lock()
+	ret, specificReturn := fake.deployReturnsOnCall[len(fake.deployArgsForCall)]
+	fake.deployArgsForCall = append(fake.deployArgsForCall, struct {
+		arg1 []byte
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
+	}{arg1Copy, arg2, arg3, arg4})
+	fake.recordInvocation("Deploy", []interface{}{arg1Copy, arg2, arg3, arg4})
+	fake.deployMutex.Unlock()
+	if fake.DeployStub != nil {
+		return fake.DeployStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getNormalisedTasksByContextReturns.result1, fake.getNormalisedTasksByContextReturns.result2
+	fakeReturns := fake.deployReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) GetNormalisedTasksByContextCallCount() int {
-	fake.getNormalisedTasksByContextMutex.RLock()
-	defer fake.getNormalisedTasksByContextMutex.RUnlock()
-	return len(fake.getNormalisedTasksByContextArgsForCall)
+func (fake *FakeBoshClient) DeployCallCount() int {
+	fake.deployMutex.RLock()
+	defer fake.deployMutex.RUnlock()
+	return len(fake.deployArgsForCall)
 }
 
-func (fake *FakeBoshClient) GetNormalisedTasksByContextArgsForCall(i int) (string, string, *log.Logger) {
-	fake.getNormalisedTasksByContextMutex.RLock()
-	defer fake.getNormalisedTasksByContextMutex.RUnlock()
-	return fake.getNormalisedTasksByContextArgsForCall[i].deploymentName, fake.getNormalisedTasksByContextArgsForCall[i].contextID, fake.getNormalisedTasksByContextArgsForCall[i].logger
+func (fake *FakeBoshClient) DeployCalls(stub func([]byte, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)) {
+	fake.deployMutex.Lock()
+	defer fake.deployMutex.Unlock()
+	fake.DeployStub = stub
 }
 
-func (fake *FakeBoshClient) GetNormalisedTasksByContextReturns(result1 boshdirector.BoshTasks, result2 error) {
-	fake.GetNormalisedTasksByContextStub = nil
-	fake.getNormalisedTasksByContextReturns = struct {
-		result1 boshdirector.BoshTasks
+func (fake *FakeBoshClient) DeployArgsForCall(i int) ([]byte, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
+	fake.deployMutex.RLock()
+	defer fake.deployMutex.RUnlock()
+	argsForCall := fake.deployArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeBoshClient) DeployReturns(result1 int, result2 error) {
+	fake.deployMutex.Lock()
+	defer fake.deployMutex.Unlock()
+	fake.DeployStub = nil
+	fake.deployReturns = struct {
+		result1 int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetNormalisedTasksByContextReturnsOnCall(i int, result1 boshdirector.BoshTasks, result2 error) {
-	fake.GetNormalisedTasksByContextStub = nil
-	if fake.getNormalisedTasksByContextReturnsOnCall == nil {
-		fake.getNormalisedTasksByContextReturnsOnCall = make(map[int]struct {
-			result1 boshdirector.BoshTasks
+func (fake *FakeBoshClient) DeployReturnsOnCall(i int, result1 int, result2 error) {
+	fake.deployMutex.Lock()
+	defer fake.deployMutex.Unlock()
+	fake.DeployStub = nil
+	if fake.deployReturnsOnCall == nil {
+		fake.deployReturnsOnCall = make(map[int]struct {
+			result1 int
 			result2 error
 		})
 	}
-	fake.getNormalisedTasksByContextReturnsOnCall[i] = struct {
-		result1 boshdirector.BoshTasks
+	fake.deployReturnsOnCall[i] = struct {
+		result1 int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) VMs(deploymentName string, logger *log.Logger) (bosh.BoshVMs, error) {
-	fake.vMsMutex.Lock()
-	ret, specificReturn := fake.vMsReturnsOnCall[len(fake.vMsArgsForCall)]
-	fake.vMsArgsForCall = append(fake.vMsArgsForCall, struct {
-		deploymentName string
-		logger         *log.Logger
-	}{deploymentName, logger})
-	fake.recordInvocation("VMs", []interface{}{deploymentName, logger})
-	fake.vMsMutex.Unlock()
-	if fake.VMsStub != nil {
-		return fake.VMsStub(deploymentName, logger)
+func (fake *FakeBoshClient) GetConfigs(arg1 string, arg2 *log.Logger) ([]boshdirector.BoshConfig, error) {
+	fake.getConfigsMutex.Lock()
+	ret, specificReturn := fake.getConfigsReturnsOnCall[len(fake.getConfigsArgsForCall)]
+	fake.getConfigsArgsForCall = append(fake.getConfigsArgsForCall, struct {
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GetConfigs", []interface{}{arg1, arg2})
+	fake.getConfigsMutex.Unlock()
+	if fake.GetConfigsStub != nil {
+		return fake.GetConfigsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.vMsReturns.result1, fake.vMsReturns.result2
+	fakeReturns := fake.getConfigsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) VMsCallCount() int {
-	fake.vMsMutex.RLock()
-	defer fake.vMsMutex.RUnlock()
-	return len(fake.vMsArgsForCall)
+func (fake *FakeBoshClient) GetConfigsCallCount() int {
+	fake.getConfigsMutex.RLock()
+	defer fake.getConfigsMutex.RUnlock()
+	return len(fake.getConfigsArgsForCall)
 }
 
-func (fake *FakeBoshClient) VMsArgsForCall(i int) (string, *log.Logger) {
-	fake.vMsMutex.RLock()
-	defer fake.vMsMutex.RUnlock()
-	return fake.vMsArgsForCall[i].deploymentName, fake.vMsArgsForCall[i].logger
+func (fake *FakeBoshClient) GetConfigsCalls(stub func(string, *log.Logger) ([]boshdirector.BoshConfig, error)) {
+	fake.getConfigsMutex.Lock()
+	defer fake.getConfigsMutex.Unlock()
+	fake.GetConfigsStub = stub
 }
 
-func (fake *FakeBoshClient) VMsReturns(result1 bosh.BoshVMs, result2 error) {
-	fake.VMsStub = nil
-	fake.vMsReturns = struct {
-		result1 bosh.BoshVMs
+func (fake *FakeBoshClient) GetConfigsArgsForCall(i int) (string, *log.Logger) {
+	fake.getConfigsMutex.RLock()
+	defer fake.getConfigsMutex.RUnlock()
+	argsForCall := fake.getConfigsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) GetConfigsReturns(result1 []boshdirector.BoshConfig, result2 error) {
+	fake.getConfigsMutex.Lock()
+	defer fake.getConfigsMutex.Unlock()
+	fake.GetConfigsStub = nil
+	fake.getConfigsReturns = struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) VMsReturnsOnCall(i int, result1 bosh.BoshVMs, result2 error) {
-	fake.VMsStub = nil
-	if fake.vMsReturnsOnCall == nil {
-		fake.vMsReturnsOnCall = make(map[int]struct {
-			result1 bosh.BoshVMs
+func (fake *FakeBoshClient) GetConfigsReturnsOnCall(i int, result1 []boshdirector.BoshConfig, result2 error) {
+	fake.getConfigsMutex.Lock()
+	defer fake.getConfigsMutex.Unlock()
+	fake.GetConfigsStub = nil
+	if fake.getConfigsReturnsOnCall == nil {
+		fake.getConfigsReturnsOnCall = make(map[int]struct {
+			result1 []boshdirector.BoshConfig
 			result2 error
 		})
 	}
-	fake.vMsReturnsOnCall[i] = struct {
-		result1 bosh.BoshVMs
+	fake.getConfigsReturnsOnCall[i] = struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetDeployment(name string, logger *log.Logger) ([]byte, bool, error) {
+func (fake *FakeBoshClient) GetDNSAddresses(arg1 string, arg2 []config.BindingDNS) (map[string]string, error) {
+	var arg2Copy []config.BindingDNS
+	if arg2 != nil {
+		arg2Copy = make([]config.BindingDNS, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.getDNSAddressesMutex.Lock()
+	ret, specificReturn := fake.getDNSAddressesReturnsOnCall[len(fake.getDNSAddressesArgsForCall)]
+	fake.getDNSAddressesArgsForCall = append(fake.getDNSAddressesArgsForCall, struct {
+		arg1 string
+		arg2 []config.BindingDNS
+	}{arg1, arg2Copy})
+	fake.recordInvocation("GetDNSAddresses", []interface{}{arg1, arg2Copy})
+	fake.getDNSAddressesMutex.Unlock()
+	if fake.GetDNSAddressesStub != nil {
+		return fake.GetDNSAddressesStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getDNSAddressesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBoshClient) GetDNSAddressesCallCount() int {
+	fake.getDNSAddressesMutex.RLock()
+	defer fake.getDNSAddressesMutex.RUnlock()
+	return len(fake.getDNSAddressesArgsForCall)
+}
+
+func (fake *FakeBoshClient) GetDNSAddressesCalls(stub func(string, []config.BindingDNS) (map[string]string, error)) {
+	fake.getDNSAddressesMutex.Lock()
+	defer fake.getDNSAddressesMutex.Unlock()
+	fake.GetDNSAddressesStub = stub
+}
+
+func (fake *FakeBoshClient) GetDNSAddressesArgsForCall(i int) (string, []config.BindingDNS) {
+	fake.getDNSAddressesMutex.RLock()
+	defer fake.getDNSAddressesMutex.RUnlock()
+	argsForCall := fake.getDNSAddressesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) GetDNSAddressesReturns(result1 map[string]string, result2 error) {
+	fake.getDNSAddressesMutex.Lock()
+	defer fake.getDNSAddressesMutex.Unlock()
+	fake.GetDNSAddressesStub = nil
+	fake.getDNSAddressesReturns = struct {
+		result1 map[string]string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) GetDNSAddressesReturnsOnCall(i int, result1 map[string]string, result2 error) {
+	fake.getDNSAddressesMutex.Lock()
+	defer fake.getDNSAddressesMutex.Unlock()
+	fake.GetDNSAddressesStub = nil
+	if fake.getDNSAddressesReturnsOnCall == nil {
+		fake.getDNSAddressesReturnsOnCall = make(map[int]struct {
+			result1 map[string]string
+			result2 error
+		})
+	}
+	fake.getDNSAddressesReturnsOnCall[i] = struct {
+		result1 map[string]string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) GetDeployment(arg1 string, arg2 *log.Logger) ([]byte, bool, error) {
 	fake.getDeploymentMutex.Lock()
 	ret, specificReturn := fake.getDeploymentReturnsOnCall[len(fake.getDeploymentArgsForCall)]
 	fake.getDeploymentArgsForCall = append(fake.getDeploymentArgsForCall, struct {
-		name   string
-		logger *log.Logger
-	}{name, logger})
-	fake.recordInvocation("GetDeployment", []interface{}{name, logger})
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GetDeployment", []interface{}{arg1, arg2})
 	fake.getDeploymentMutex.Unlock()
 	if fake.GetDeploymentStub != nil {
-		return fake.GetDeploymentStub(name, logger)
+		return fake.GetDeploymentStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.getDeploymentReturns.result1, fake.getDeploymentReturns.result2, fake.getDeploymentReturns.result3
+	fakeReturns := fake.getDeploymentReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeBoshClient) GetDeploymentCallCount() int {
@@ -453,13 +623,22 @@ func (fake *FakeBoshClient) GetDeploymentCallCount() int {
 	return len(fake.getDeploymentArgsForCall)
 }
 
+func (fake *FakeBoshClient) GetDeploymentCalls(stub func(string, *log.Logger) ([]byte, bool, error)) {
+	fake.getDeploymentMutex.Lock()
+	defer fake.getDeploymentMutex.Unlock()
+	fake.GetDeploymentStub = stub
+}
+
 func (fake *FakeBoshClient) GetDeploymentArgsForCall(i int) (string, *log.Logger) {
 	fake.getDeploymentMutex.RLock()
 	defer fake.getDeploymentMutex.RUnlock()
-	return fake.getDeploymentArgsForCall[i].name, fake.getDeploymentArgsForCall[i].logger
+	argsForCall := fake.getDeploymentArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeBoshClient) GetDeploymentReturns(result1 []byte, result2 bool, result3 error) {
+	fake.getDeploymentMutex.Lock()
+	defer fake.getDeploymentMutex.Unlock()
 	fake.GetDeploymentStub = nil
 	fake.getDeploymentReturns = struct {
 		result1 []byte
@@ -469,6 +648,8 @@ func (fake *FakeBoshClient) GetDeploymentReturns(result1 []byte, result2 bool, r
 }
 
 func (fake *FakeBoshClient) GetDeploymentReturnsOnCall(i int, result1 []byte, result2 bool, result3 error) {
+	fake.getDeploymentMutex.Lock()
+	defer fake.getDeploymentMutex.Unlock()
 	fake.GetDeploymentStub = nil
 	if fake.getDeploymentReturnsOnCall == nil {
 		fake.getDeploymentReturnsOnCall = make(map[int]struct {
@@ -484,21 +665,22 @@ func (fake *FakeBoshClient) GetDeploymentReturnsOnCall(i int, result1 []byte, re
 	}{result1, result2, result3}
 }
 
-func (fake *FakeBoshClient) GetDeployments(logger *log.Logger) ([]boshdirector.Deployment, error) {
+func (fake *FakeBoshClient) GetDeployments(arg1 *log.Logger) ([]boshdirector.Deployment, error) {
 	fake.getDeploymentsMutex.Lock()
 	ret, specificReturn := fake.getDeploymentsReturnsOnCall[len(fake.getDeploymentsArgsForCall)]
 	fake.getDeploymentsArgsForCall = append(fake.getDeploymentsArgsForCall, struct {
-		logger *log.Logger
-	}{logger})
-	fake.recordInvocation("GetDeployments", []interface{}{logger})
+		arg1 *log.Logger
+	}{arg1})
+	fake.recordInvocation("GetDeployments", []interface{}{arg1})
 	fake.getDeploymentsMutex.Unlock()
 	if fake.GetDeploymentsStub != nil {
-		return fake.GetDeploymentsStub(logger)
+		return fake.GetDeploymentsStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getDeploymentsReturns.result1, fake.getDeploymentsReturns.result2
+	fakeReturns := fake.getDeploymentsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeBoshClient) GetDeploymentsCallCount() int {
@@ -507,13 +689,22 @@ func (fake *FakeBoshClient) GetDeploymentsCallCount() int {
 	return len(fake.getDeploymentsArgsForCall)
 }
 
+func (fake *FakeBoshClient) GetDeploymentsCalls(stub func(*log.Logger) ([]boshdirector.Deployment, error)) {
+	fake.getDeploymentsMutex.Lock()
+	defer fake.getDeploymentsMutex.Unlock()
+	fake.GetDeploymentsStub = stub
+}
+
 func (fake *FakeBoshClient) GetDeploymentsArgsForCall(i int) *log.Logger {
 	fake.getDeploymentsMutex.RLock()
 	defer fake.getDeploymentsMutex.RUnlock()
-	return fake.getDeploymentsArgsForCall[i].logger
+	argsForCall := fake.getDeploymentsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeBoshClient) GetDeploymentsReturns(result1 []boshdirector.Deployment, result2 error) {
+	fake.getDeploymentsMutex.Lock()
+	defer fake.getDeploymentsMutex.Unlock()
 	fake.GetDeploymentsStub = nil
 	fake.getDeploymentsReturns = struct {
 		result1 []boshdirector.Deployment
@@ -522,6 +713,8 @@ func (fake *FakeBoshClient) GetDeploymentsReturns(result1 []boshdirector.Deploym
 }
 
 func (fake *FakeBoshClient) GetDeploymentsReturnsOnCall(i int, result1 []boshdirector.Deployment, result2 error) {
+	fake.getDeploymentsMutex.Lock()
+	defer fake.getDeploymentsMutex.Unlock()
 	fake.GetDeploymentsStub = nil
 	if fake.getDeploymentsReturnsOnCall == nil {
 		fake.getDeploymentsReturnsOnCall = make(map[int]struct {
@@ -535,75 +728,22 @@ func (fake *FakeBoshClient) GetDeploymentsReturnsOnCall(i int, result1 []boshdir
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) DeleteDeployment(name string, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error) {
-	fake.deleteDeploymentMutex.Lock()
-	ret, specificReturn := fake.deleteDeploymentReturnsOnCall[len(fake.deleteDeploymentArgsForCall)]
-	fake.deleteDeploymentArgsForCall = append(fake.deleteDeploymentArgsForCall, struct {
-		name         string
-		contextID    string
-		logger       *log.Logger
-		taskReporter *boshdirector.AsyncTaskReporter
-	}{name, contextID, logger, taskReporter})
-	fake.recordInvocation("DeleteDeployment", []interface{}{name, contextID, logger, taskReporter})
-	fake.deleteDeploymentMutex.Unlock()
-	if fake.DeleteDeploymentStub != nil {
-		return fake.DeleteDeploymentStub(name, contextID, logger, taskReporter)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.deleteDeploymentReturns.result1, fake.deleteDeploymentReturns.result2
-}
-
-func (fake *FakeBoshClient) DeleteDeploymentCallCount() int {
-	fake.deleteDeploymentMutex.RLock()
-	defer fake.deleteDeploymentMutex.RUnlock()
-	return len(fake.deleteDeploymentArgsForCall)
-}
-
-func (fake *FakeBoshClient) DeleteDeploymentArgsForCall(i int) (string, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
-	fake.deleteDeploymentMutex.RLock()
-	defer fake.deleteDeploymentMutex.RUnlock()
-	return fake.deleteDeploymentArgsForCall[i].name, fake.deleteDeploymentArgsForCall[i].contextID, fake.deleteDeploymentArgsForCall[i].logger, fake.deleteDeploymentArgsForCall[i].taskReporter
-}
-
-func (fake *FakeBoshClient) DeleteDeploymentReturns(result1 int, result2 error) {
-	fake.DeleteDeploymentStub = nil
-	fake.deleteDeploymentReturns = struct {
-		result1 int
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeBoshClient) DeleteDeploymentReturnsOnCall(i int, result1 int, result2 error) {
-	fake.DeleteDeploymentStub = nil
-	if fake.deleteDeploymentReturnsOnCall == nil {
-		fake.deleteDeploymentReturnsOnCall = make(map[int]struct {
-			result1 int
-			result2 error
-		})
-	}
-	fake.deleteDeploymentReturnsOnCall[i] = struct {
-		result1 int
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeBoshClient) GetInfo(logger *log.Logger) (boshdirector.Info, error) {
+func (fake *FakeBoshClient) GetInfo(arg1 *log.Logger) (boshdirector.Info, error) {
 	fake.getInfoMutex.Lock()
 	ret, specificReturn := fake.getInfoReturnsOnCall[len(fake.getInfoArgsForCall)]
 	fake.getInfoArgsForCall = append(fake.getInfoArgsForCall, struct {
-		logger *log.Logger
-	}{logger})
-	fake.recordInvocation("GetInfo", []interface{}{logger})
+		arg1 *log.Logger
+	}{arg1})
+	fake.recordInvocation("GetInfo", []interface{}{arg1})
 	fake.getInfoMutex.Unlock()
 	if fake.GetInfoStub != nil {
-		return fake.GetInfoStub(logger)
+		return fake.GetInfoStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getInfoReturns.result1, fake.getInfoReturns.result2
+	fakeReturns := fake.getInfoReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeBoshClient) GetInfoCallCount() int {
@@ -612,13 +752,22 @@ func (fake *FakeBoshClient) GetInfoCallCount() int {
 	return len(fake.getInfoArgsForCall)
 }
 
+func (fake *FakeBoshClient) GetInfoCalls(stub func(*log.Logger) (boshdirector.Info, error)) {
+	fake.getInfoMutex.Lock()
+	defer fake.getInfoMutex.Unlock()
+	fake.GetInfoStub = stub
+}
+
 func (fake *FakeBoshClient) GetInfoArgsForCall(i int) *log.Logger {
 	fake.getInfoMutex.RLock()
 	defer fake.getInfoMutex.RUnlock()
-	return fake.getInfoArgsForCall[i].logger
+	argsForCall := fake.getInfoArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeBoshClient) GetInfoReturns(result1 boshdirector.Info, result2 error) {
+	fake.getInfoMutex.Lock()
+	defer fake.getInfoMutex.Unlock()
 	fake.GetInfoStub = nil
 	fake.getInfoReturns = struct {
 		result1 boshdirector.Info
@@ -627,6 +776,8 @@ func (fake *FakeBoshClient) GetInfoReturns(result1 boshdirector.Info, result2 er
 }
 
 func (fake *FakeBoshClient) GetInfoReturnsOnCall(i int, result1 boshdirector.Info, result2 error) {
+	fake.getInfoMutex.Lock()
+	defer fake.getInfoMutex.Unlock()
 	fake.GetInfoStub = nil
 	if fake.getInfoReturnsOnCall == nil {
 		fake.getInfoReturnsOnCall = make(map[int]struct {
@@ -640,301 +791,218 @@ func (fake *FakeBoshClient) GetInfoReturnsOnCall(i int, result1 boshdirector.Inf
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) RunErrand(deploymentName string, errandName string, errandInstances []string, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error) {
-	var errandInstancesCopy []string
-	if errandInstances != nil {
-		errandInstancesCopy = make([]string, len(errandInstances))
-		copy(errandInstancesCopy, errandInstances)
-	}
-	fake.runErrandMutex.Lock()
-	ret, specificReturn := fake.runErrandReturnsOnCall[len(fake.runErrandArgsForCall)]
-	fake.runErrandArgsForCall = append(fake.runErrandArgsForCall, struct {
-		deploymentName  string
-		errandName      string
-		errandInstances []string
-		contextID       string
-		logger          *log.Logger
-		taskReporter    *boshdirector.AsyncTaskReporter
-	}{deploymentName, errandName, errandInstancesCopy, contextID, logger, taskReporter})
-	fake.recordInvocation("RunErrand", []interface{}{deploymentName, errandName, errandInstancesCopy, contextID, logger, taskReporter})
-	fake.runErrandMutex.Unlock()
-	if fake.RunErrandStub != nil {
-		return fake.RunErrandStub(deploymentName, errandName, errandInstances, contextID, logger, taskReporter)
+func (fake *FakeBoshClient) GetNormalisedTasksByContext(arg1 string, arg2 string, arg3 *log.Logger) (boshdirector.BoshTasks, error) {
+	fake.getNormalisedTasksByContextMutex.Lock()
+	ret, specificReturn := fake.getNormalisedTasksByContextReturnsOnCall[len(fake.getNormalisedTasksByContextArgsForCall)]
+	fake.getNormalisedTasksByContextArgsForCall = append(fake.getNormalisedTasksByContextArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetNormalisedTasksByContext", []interface{}{arg1, arg2, arg3})
+	fake.getNormalisedTasksByContextMutex.Unlock()
+	if fake.GetNormalisedTasksByContextStub != nil {
+		return fake.GetNormalisedTasksByContextStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.runErrandReturns.result1, fake.runErrandReturns.result2
+	fakeReturns := fake.getNormalisedTasksByContextReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) RunErrandCallCount() int {
-	fake.runErrandMutex.RLock()
-	defer fake.runErrandMutex.RUnlock()
-	return len(fake.runErrandArgsForCall)
+func (fake *FakeBoshClient) GetNormalisedTasksByContextCallCount() int {
+	fake.getNormalisedTasksByContextMutex.RLock()
+	defer fake.getNormalisedTasksByContextMutex.RUnlock()
+	return len(fake.getNormalisedTasksByContextArgsForCall)
 }
 
-func (fake *FakeBoshClient) RunErrandArgsForCall(i int) (string, string, []string, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
-	fake.runErrandMutex.RLock()
-	defer fake.runErrandMutex.RUnlock()
-	return fake.runErrandArgsForCall[i].deploymentName, fake.runErrandArgsForCall[i].errandName, fake.runErrandArgsForCall[i].errandInstances, fake.runErrandArgsForCall[i].contextID, fake.runErrandArgsForCall[i].logger, fake.runErrandArgsForCall[i].taskReporter
+func (fake *FakeBoshClient) GetNormalisedTasksByContextCalls(stub func(string, string, *log.Logger) (boshdirector.BoshTasks, error)) {
+	fake.getNormalisedTasksByContextMutex.Lock()
+	defer fake.getNormalisedTasksByContextMutex.Unlock()
+	fake.GetNormalisedTasksByContextStub = stub
 }
 
-func (fake *FakeBoshClient) RunErrandReturns(result1 int, result2 error) {
-	fake.RunErrandStub = nil
-	fake.runErrandReturns = struct {
-		result1 int
+func (fake *FakeBoshClient) GetNormalisedTasksByContextArgsForCall(i int) (string, string, *log.Logger) {
+	fake.getNormalisedTasksByContextMutex.RLock()
+	defer fake.getNormalisedTasksByContextMutex.RUnlock()
+	argsForCall := fake.getNormalisedTasksByContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeBoshClient) GetNormalisedTasksByContextReturns(result1 boshdirector.BoshTasks, result2 error) {
+	fake.getNormalisedTasksByContextMutex.Lock()
+	defer fake.getNormalisedTasksByContextMutex.Unlock()
+	fake.GetNormalisedTasksByContextStub = nil
+	fake.getNormalisedTasksByContextReturns = struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) RunErrandReturnsOnCall(i int, result1 int, result2 error) {
-	fake.RunErrandStub = nil
-	if fake.runErrandReturnsOnCall == nil {
-		fake.runErrandReturnsOnCall = make(map[int]struct {
-			result1 int
+func (fake *FakeBoshClient) GetNormalisedTasksByContextReturnsOnCall(i int, result1 boshdirector.BoshTasks, result2 error) {
+	fake.getNormalisedTasksByContextMutex.Lock()
+	defer fake.getNormalisedTasksByContextMutex.Unlock()
+	fake.GetNormalisedTasksByContextStub = nil
+	if fake.getNormalisedTasksByContextReturnsOnCall == nil {
+		fake.getNormalisedTasksByContextReturnsOnCall = make(map[int]struct {
+			result1 boshdirector.BoshTasks
 			result2 error
 		})
 	}
-	fake.runErrandReturnsOnCall[i] = struct {
-		result1 int
+	fake.getNormalisedTasksByContextReturnsOnCall[i] = struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) Variables(deploymentName string, logger *log.Logger) ([]boshdirector.Variable, error) {
-	fake.variablesMutex.Lock()
-	ret, specificReturn := fake.variablesReturnsOnCall[len(fake.variablesArgsForCall)]
-	fake.variablesArgsForCall = append(fake.variablesArgsForCall, struct {
-		deploymentName string
-		logger         *log.Logger
-	}{deploymentName, logger})
-	fake.recordInvocation("Variables", []interface{}{deploymentName, logger})
-	fake.variablesMutex.Unlock()
-	if fake.VariablesStub != nil {
-		return fake.VariablesStub(deploymentName, logger)
+func (fake *FakeBoshClient) GetTask(arg1 int, arg2 *log.Logger) (boshdirector.BoshTask, error) {
+	fake.getTaskMutex.Lock()
+	ret, specificReturn := fake.getTaskReturnsOnCall[len(fake.getTaskArgsForCall)]
+	fake.getTaskArgsForCall = append(fake.getTaskArgsForCall, struct {
+		arg1 int
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GetTask", []interface{}{arg1, arg2})
+	fake.getTaskMutex.Unlock()
+	if fake.GetTaskStub != nil {
+		return fake.GetTaskStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.variablesReturns.result1, fake.variablesReturns.result2
+	fakeReturns := fake.getTaskReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) VariablesCallCount() int {
-	fake.variablesMutex.RLock()
-	defer fake.variablesMutex.RUnlock()
-	return len(fake.variablesArgsForCall)
+func (fake *FakeBoshClient) GetTaskCallCount() int {
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
+	return len(fake.getTaskArgsForCall)
 }
 
-func (fake *FakeBoshClient) VariablesArgsForCall(i int) (string, *log.Logger) {
-	fake.variablesMutex.RLock()
-	defer fake.variablesMutex.RUnlock()
-	return fake.variablesArgsForCall[i].deploymentName, fake.variablesArgsForCall[i].logger
+func (fake *FakeBoshClient) GetTaskCalls(stub func(int, *log.Logger) (boshdirector.BoshTask, error)) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = stub
 }
 
-func (fake *FakeBoshClient) VariablesReturns(result1 []boshdirector.Variable, result2 error) {
-	fake.VariablesStub = nil
-	fake.variablesReturns = struct {
-		result1 []boshdirector.Variable
+func (fake *FakeBoshClient) GetTaskArgsForCall(i int) (int, *log.Logger) {
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
+	argsForCall := fake.getTaskArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) GetTaskReturns(result1 boshdirector.BoshTask, result2 error) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = nil
+	fake.getTaskReturns = struct {
+		result1 boshdirector.BoshTask
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) VariablesReturnsOnCall(i int, result1 []boshdirector.Variable, result2 error) {
-	fake.VariablesStub = nil
-	if fake.variablesReturnsOnCall == nil {
-		fake.variablesReturnsOnCall = make(map[int]struct {
-			result1 []boshdirector.Variable
+func (fake *FakeBoshClient) GetTaskReturnsOnCall(i int, result1 boshdirector.BoshTask, result2 error) {
+	fake.getTaskMutex.Lock()
+	defer fake.getTaskMutex.Unlock()
+	fake.GetTaskStub = nil
+	if fake.getTaskReturnsOnCall == nil {
+		fake.getTaskReturnsOnCall = make(map[int]struct {
+			result1 boshdirector.BoshTask
 			result2 error
 		})
 	}
-	fake.variablesReturnsOnCall[i] = struct {
-		result1 []boshdirector.Variable
+	fake.getTaskReturnsOnCall[i] = struct {
+		result1 boshdirector.BoshTask
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) VerifyAuth(logger *log.Logger) error {
-	fake.verifyAuthMutex.Lock()
-	ret, specificReturn := fake.verifyAuthReturnsOnCall[len(fake.verifyAuthArgsForCall)]
-	fake.verifyAuthArgsForCall = append(fake.verifyAuthArgsForCall, struct {
-		logger *log.Logger
-	}{logger})
-	fake.recordInvocation("VerifyAuth", []interface{}{logger})
-	fake.verifyAuthMutex.Unlock()
-	if fake.VerifyAuthStub != nil {
-		return fake.VerifyAuthStub(logger)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.verifyAuthReturns.result1
-}
-
-func (fake *FakeBoshClient) VerifyAuthCallCount() int {
-	fake.verifyAuthMutex.RLock()
-	defer fake.verifyAuthMutex.RUnlock()
-	return len(fake.verifyAuthArgsForCall)
-}
-
-func (fake *FakeBoshClient) VerifyAuthArgsForCall(i int) *log.Logger {
-	fake.verifyAuthMutex.RLock()
-	defer fake.verifyAuthMutex.RUnlock()
-	return fake.verifyAuthArgsForCall[i].logger
-}
-
-func (fake *FakeBoshClient) VerifyAuthReturns(result1 error) {
-	fake.VerifyAuthStub = nil
-	fake.verifyAuthReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeBoshClient) VerifyAuthReturnsOnCall(i int, result1 error) {
-	fake.VerifyAuthStub = nil
-	if fake.verifyAuthReturnsOnCall == nil {
-		fake.verifyAuthReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.verifyAuthReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeBoshClient) GetDNSAddresses(deploymentName string, requestedDNS []config.BindingDNS) (map[string]string, error) {
-	var requestedDNSCopy []config.BindingDNS
-	if requestedDNS != nil {
-		requestedDNSCopy = make([]config.BindingDNS, len(requestedDNS))
-		copy(requestedDNSCopy, requestedDNS)
-	}
-	fake.getDNSAddressesMutex.Lock()
-	ret, specificReturn := fake.getDNSAddressesReturnsOnCall[len(fake.getDNSAddressesArgsForCall)]
-	fake.getDNSAddressesArgsForCall = append(fake.getDNSAddressesArgsForCall, struct {
-		deploymentName string
-		requestedDNS   []config.BindingDNS
-	}{deploymentName, requestedDNSCopy})
-	fake.recordInvocation("GetDNSAddresses", []interface{}{deploymentName, requestedDNSCopy})
-	fake.getDNSAddressesMutex.Unlock()
-	if fake.GetDNSAddressesStub != nil {
-		return fake.GetDNSAddressesStub(deploymentName, requestedDNS)
+func (fake *FakeBoshClient) GetTasks(arg1 string, arg2 *log.Logger) (boshdirector.BoshTasks, error) {
+	fake.getTasksMutex.Lock()
+	ret, specificReturn := fake.getTasksReturnsOnCall[len(fake.getTasksArgsForCall)]
+	fake.getTasksArgsForCall = append(fake.getTasksArgsForCall, struct {
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GetTasks", []interface{}{arg1, arg2})
+	fake.getTasksMutex.Unlock()
+	if fake.GetTasksStub != nil {
+		return fake.GetTasksStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getDNSAddressesReturns.result1, fake.getDNSAddressesReturns.result2
+	fakeReturns := fake.getTasksReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) GetDNSAddressesCallCount() int {
-	fake.getDNSAddressesMutex.RLock()
-	defer fake.getDNSAddressesMutex.RUnlock()
-	return len(fake.getDNSAddressesArgsForCall)
+func (fake *FakeBoshClient) GetTasksCallCount() int {
+	fake.getTasksMutex.RLock()
+	defer fake.getTasksMutex.RUnlock()
+	return len(fake.getTasksArgsForCall)
 }
 
-func (fake *FakeBoshClient) GetDNSAddressesArgsForCall(i int) (string, []config.BindingDNS) {
-	fake.getDNSAddressesMutex.RLock()
-	defer fake.getDNSAddressesMutex.RUnlock()
-	return fake.getDNSAddressesArgsForCall[i].deploymentName, fake.getDNSAddressesArgsForCall[i].requestedDNS
+func (fake *FakeBoshClient) GetTasksCalls(stub func(string, *log.Logger) (boshdirector.BoshTasks, error)) {
+	fake.getTasksMutex.Lock()
+	defer fake.getTasksMutex.Unlock()
+	fake.GetTasksStub = stub
 }
 
-func (fake *FakeBoshClient) GetDNSAddressesReturns(result1 map[string]string, result2 error) {
-	fake.GetDNSAddressesStub = nil
-	fake.getDNSAddressesReturns = struct {
-		result1 map[string]string
+func (fake *FakeBoshClient) GetTasksArgsForCall(i int) (string, *log.Logger) {
+	fake.getTasksMutex.RLock()
+	defer fake.getTasksMutex.RUnlock()
+	argsForCall := fake.getTasksArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) GetTasksReturns(result1 boshdirector.BoshTasks, result2 error) {
+	fake.getTasksMutex.Lock()
+	defer fake.getTasksMutex.Unlock()
+	fake.GetTasksStub = nil
+	fake.getTasksReturns = struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetDNSAddressesReturnsOnCall(i int, result1 map[string]string, result2 error) {
-	fake.GetDNSAddressesStub = nil
-	if fake.getDNSAddressesReturnsOnCall == nil {
-		fake.getDNSAddressesReturnsOnCall = make(map[int]struct {
-			result1 map[string]string
+func (fake *FakeBoshClient) GetTasksReturnsOnCall(i int, result1 boshdirector.BoshTasks, result2 error) {
+	fake.getTasksMutex.Lock()
+	defer fake.getTasksMutex.Unlock()
+	fake.GetTasksStub = nil
+	if fake.getTasksReturnsOnCall == nil {
+		fake.getTasksReturnsOnCall = make(map[int]struct {
+			result1 boshdirector.BoshTasks
 			result2 error
 		})
 	}
-	fake.getDNSAddressesReturnsOnCall[i] = struct {
-		result1 map[string]string
+	fake.getTasksReturnsOnCall[i] = struct {
+		result1 boshdirector.BoshTasks
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) Deploy(manifest []byte, contextID string, logger *log.Logger, reporter *boshdirector.AsyncTaskReporter) (int, error) {
-	var manifestCopy []byte
-	if manifest != nil {
-		manifestCopy = make([]byte, len(manifest))
-		copy(manifestCopy, manifest)
-	}
-	fake.deployMutex.Lock()
-	ret, specificReturn := fake.deployReturnsOnCall[len(fake.deployArgsForCall)]
-	fake.deployArgsForCall = append(fake.deployArgsForCall, struct {
-		manifest  []byte
-		contextID string
-		logger    *log.Logger
-		reporter  *boshdirector.AsyncTaskReporter
-	}{manifestCopy, contextID, logger, reporter})
-	fake.recordInvocation("Deploy", []interface{}{manifestCopy, contextID, logger, reporter})
-	fake.deployMutex.Unlock()
-	if fake.DeployStub != nil {
-		return fake.DeployStub(manifest, contextID, logger, reporter)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.deployReturns.result1, fake.deployReturns.result2
-}
-
-func (fake *FakeBoshClient) DeployCallCount() int {
-	fake.deployMutex.RLock()
-	defer fake.deployMutex.RUnlock()
-	return len(fake.deployArgsForCall)
-}
-
-func (fake *FakeBoshClient) DeployArgsForCall(i int) ([]byte, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
-	fake.deployMutex.RLock()
-	defer fake.deployMutex.RUnlock()
-	return fake.deployArgsForCall[i].manifest, fake.deployArgsForCall[i].contextID, fake.deployArgsForCall[i].logger, fake.deployArgsForCall[i].reporter
-}
-
-func (fake *FakeBoshClient) DeployReturns(result1 int, result2 error) {
-	fake.DeployStub = nil
-	fake.deployReturns = struct {
-		result1 int
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeBoshClient) DeployReturnsOnCall(i int, result1 int, result2 error) {
-	fake.DeployStub = nil
-	if fake.deployReturnsOnCall == nil {
-		fake.deployReturnsOnCall = make(map[int]struct {
-			result1 int
-			result2 error
-		})
-	}
-	fake.deployReturnsOnCall[i] = struct {
-		result1 int
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeBoshClient) Recreate(deploymentName string, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error) {
+func (fake *FakeBoshClient) Recreate(arg1 string, arg2 string, arg3 *log.Logger, arg4 *boshdirector.AsyncTaskReporter) (int, error) {
 	fake.recreateMutex.Lock()
 	ret, specificReturn := fake.recreateReturnsOnCall[len(fake.recreateArgsForCall)]
 	fake.recreateArgsForCall = append(fake.recreateArgsForCall, struct {
-		deploymentName string
-		contextID      string
-		logger         *log.Logger
-		taskReporter   *boshdirector.AsyncTaskReporter
-	}{deploymentName, contextID, logger, taskReporter})
-	fake.recordInvocation("Recreate", []interface{}{deploymentName, contextID, logger, taskReporter})
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("Recreate", []interface{}{arg1, arg2, arg3, arg4})
 	fake.recreateMutex.Unlock()
 	if fake.RecreateStub != nil {
-		return fake.RecreateStub(deploymentName, contextID, logger, taskReporter)
+		return fake.RecreateStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.recreateReturns.result1, fake.recreateReturns.result2
+	fakeReturns := fake.recreateReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeBoshClient) RecreateCallCount() int {
@@ -943,13 +1011,22 @@ func (fake *FakeBoshClient) RecreateCallCount() int {
 	return len(fake.recreateArgsForCall)
 }
 
+func (fake *FakeBoshClient) RecreateCalls(stub func(string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)) {
+	fake.recreateMutex.Lock()
+	defer fake.recreateMutex.Unlock()
+	fake.RecreateStub = stub
+}
+
 func (fake *FakeBoshClient) RecreateArgsForCall(i int) (string, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
 	fake.recreateMutex.RLock()
 	defer fake.recreateMutex.RUnlock()
-	return fake.recreateArgsForCall[i].deploymentName, fake.recreateArgsForCall[i].contextID, fake.recreateArgsForCall[i].logger, fake.recreateArgsForCall[i].taskReporter
+	argsForCall := fake.recreateArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeBoshClient) RecreateReturns(result1 int, result2 error) {
+	fake.recreateMutex.Lock()
+	defer fake.recreateMutex.Unlock()
 	fake.RecreateStub = nil
 	fake.recreateReturns = struct {
 		result1 int
@@ -958,6 +1035,8 @@ func (fake *FakeBoshClient) RecreateReturns(result1 int, result2 error) {
 }
 
 func (fake *FakeBoshClient) RecreateReturnsOnCall(i int, result1 int, result2 error) {
+	fake.recreateMutex.Lock()
+	defer fake.recreateMutex.Unlock()
 	fake.RecreateStub = nil
 	if fake.recreateReturnsOnCall == nil {
 		fake.recreateReturnsOnCall = make(map[int]struct {
@@ -971,37 +1050,372 @@ func (fake *FakeBoshClient) RecreateReturnsOnCall(i int, result1 int, result2 er
 	}{result1, result2}
 }
 
+func (fake *FakeBoshClient) RunErrand(arg1 string, arg2 string, arg3 []string, arg4 string, arg5 *log.Logger, arg6 *boshdirector.AsyncTaskReporter) (int, error) {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.runErrandMutex.Lock()
+	ret, specificReturn := fake.runErrandReturnsOnCall[len(fake.runErrandArgsForCall)]
+	fake.runErrandArgsForCall = append(fake.runErrandArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 []string
+		arg4 string
+		arg5 *log.Logger
+		arg6 *boshdirector.AsyncTaskReporter
+	}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
+	fake.recordInvocation("RunErrand", []interface{}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
+	fake.runErrandMutex.Unlock()
+	if fake.RunErrandStub != nil {
+		return fake.RunErrandStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.runErrandReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBoshClient) RunErrandCallCount() int {
+	fake.runErrandMutex.RLock()
+	defer fake.runErrandMutex.RUnlock()
+	return len(fake.runErrandArgsForCall)
+}
+
+func (fake *FakeBoshClient) RunErrandCalls(stub func(string, string, []string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)) {
+	fake.runErrandMutex.Lock()
+	defer fake.runErrandMutex.Unlock()
+	fake.RunErrandStub = stub
+}
+
+func (fake *FakeBoshClient) RunErrandArgsForCall(i int) (string, string, []string, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
+	fake.runErrandMutex.RLock()
+	defer fake.runErrandMutex.RUnlock()
+	argsForCall := fake.runErrandArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+}
+
+func (fake *FakeBoshClient) RunErrandReturns(result1 int, result2 error) {
+	fake.runErrandMutex.Lock()
+	defer fake.runErrandMutex.Unlock()
+	fake.RunErrandStub = nil
+	fake.runErrandReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) RunErrandReturnsOnCall(i int, result1 int, result2 error) {
+	fake.runErrandMutex.Lock()
+	defer fake.runErrandMutex.Unlock()
+	fake.RunErrandStub = nil
+	if fake.runErrandReturnsOnCall == nil {
+		fake.runErrandReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.runErrandReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) UpdateConfig(arg1 string, arg2 string, arg3 []byte, arg4 *log.Logger) error {
+	var arg3Copy []byte
+	if arg3 != nil {
+		arg3Copy = make([]byte, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.updateConfigMutex.Lock()
+	ret, specificReturn := fake.updateConfigReturnsOnCall[len(fake.updateConfigArgsForCall)]
+	fake.updateConfigArgsForCall = append(fake.updateConfigArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 []byte
+		arg4 *log.Logger
+	}{arg1, arg2, arg3Copy, arg4})
+	fake.recordInvocation("UpdateConfig", []interface{}{arg1, arg2, arg3Copy, arg4})
+	fake.updateConfigMutex.Unlock()
+	if fake.UpdateConfigStub != nil {
+		return fake.UpdateConfigStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.updateConfigReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeBoshClient) UpdateConfigCallCount() int {
+	fake.updateConfigMutex.RLock()
+	defer fake.updateConfigMutex.RUnlock()
+	return len(fake.updateConfigArgsForCall)
+}
+
+func (fake *FakeBoshClient) UpdateConfigCalls(stub func(string, string, []byte, *log.Logger) error) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = stub
+}
+
+func (fake *FakeBoshClient) UpdateConfigArgsForCall(i int) (string, string, []byte, *log.Logger) {
+	fake.updateConfigMutex.RLock()
+	defer fake.updateConfigMutex.RUnlock()
+	argsForCall := fake.updateConfigArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeBoshClient) UpdateConfigReturns(result1 error) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = nil
+	fake.updateConfigReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBoshClient) UpdateConfigReturnsOnCall(i int, result1 error) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = nil
+	if fake.updateConfigReturnsOnCall == nil {
+		fake.updateConfigReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBoshClient) VMs(arg1 string, arg2 *log.Logger) (bosh.BoshVMs, error) {
+	fake.vMsMutex.Lock()
+	ret, specificReturn := fake.vMsReturnsOnCall[len(fake.vMsArgsForCall)]
+	fake.vMsArgsForCall = append(fake.vMsArgsForCall, struct {
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("VMs", []interface{}{arg1, arg2})
+	fake.vMsMutex.Unlock()
+	if fake.VMsStub != nil {
+		return fake.VMsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.vMsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBoshClient) VMsCallCount() int {
+	fake.vMsMutex.RLock()
+	defer fake.vMsMutex.RUnlock()
+	return len(fake.vMsArgsForCall)
+}
+
+func (fake *FakeBoshClient) VMsCalls(stub func(string, *log.Logger) (bosh.BoshVMs, error)) {
+	fake.vMsMutex.Lock()
+	defer fake.vMsMutex.Unlock()
+	fake.VMsStub = stub
+}
+
+func (fake *FakeBoshClient) VMsArgsForCall(i int) (string, *log.Logger) {
+	fake.vMsMutex.RLock()
+	defer fake.vMsMutex.RUnlock()
+	argsForCall := fake.vMsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) VMsReturns(result1 bosh.BoshVMs, result2 error) {
+	fake.vMsMutex.Lock()
+	defer fake.vMsMutex.Unlock()
+	fake.VMsStub = nil
+	fake.vMsReturns = struct {
+		result1 bosh.BoshVMs
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) VMsReturnsOnCall(i int, result1 bosh.BoshVMs, result2 error) {
+	fake.vMsMutex.Lock()
+	defer fake.vMsMutex.Unlock()
+	fake.VMsStub = nil
+	if fake.vMsReturnsOnCall == nil {
+		fake.vMsReturnsOnCall = make(map[int]struct {
+			result1 bosh.BoshVMs
+			result2 error
+		})
+	}
+	fake.vMsReturnsOnCall[i] = struct {
+		result1 bosh.BoshVMs
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) Variables(arg1 string, arg2 *log.Logger) ([]boshdirector.Variable, error) {
+	fake.variablesMutex.Lock()
+	ret, specificReturn := fake.variablesReturnsOnCall[len(fake.variablesArgsForCall)]
+	fake.variablesArgsForCall = append(fake.variablesArgsForCall, struct {
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("Variables", []interface{}{arg1, arg2})
+	fake.variablesMutex.Unlock()
+	if fake.VariablesStub != nil {
+		return fake.VariablesStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.variablesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBoshClient) VariablesCallCount() int {
+	fake.variablesMutex.RLock()
+	defer fake.variablesMutex.RUnlock()
+	return len(fake.variablesArgsForCall)
+}
+
+func (fake *FakeBoshClient) VariablesCalls(stub func(string, *log.Logger) ([]boshdirector.Variable, error)) {
+	fake.variablesMutex.Lock()
+	defer fake.variablesMutex.Unlock()
+	fake.VariablesStub = stub
+}
+
+func (fake *FakeBoshClient) VariablesArgsForCall(i int) (string, *log.Logger) {
+	fake.variablesMutex.RLock()
+	defer fake.variablesMutex.RUnlock()
+	argsForCall := fake.variablesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) VariablesReturns(result1 []boshdirector.Variable, result2 error) {
+	fake.variablesMutex.Lock()
+	defer fake.variablesMutex.Unlock()
+	fake.VariablesStub = nil
+	fake.variablesReturns = struct {
+		result1 []boshdirector.Variable
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) VariablesReturnsOnCall(i int, result1 []boshdirector.Variable, result2 error) {
+	fake.variablesMutex.Lock()
+	defer fake.variablesMutex.Unlock()
+	fake.VariablesStub = nil
+	if fake.variablesReturnsOnCall == nil {
+		fake.variablesReturnsOnCall = make(map[int]struct {
+			result1 []boshdirector.Variable
+			result2 error
+		})
+	}
+	fake.variablesReturnsOnCall[i] = struct {
+		result1 []boshdirector.Variable
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) VerifyAuth(arg1 *log.Logger) error {
+	fake.verifyAuthMutex.Lock()
+	ret, specificReturn := fake.verifyAuthReturnsOnCall[len(fake.verifyAuthArgsForCall)]
+	fake.verifyAuthArgsForCall = append(fake.verifyAuthArgsForCall, struct {
+		arg1 *log.Logger
+	}{arg1})
+	fake.recordInvocation("VerifyAuth", []interface{}{arg1})
+	fake.verifyAuthMutex.Unlock()
+	if fake.VerifyAuthStub != nil {
+		return fake.VerifyAuthStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.verifyAuthReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeBoshClient) VerifyAuthCallCount() int {
+	fake.verifyAuthMutex.RLock()
+	defer fake.verifyAuthMutex.RUnlock()
+	return len(fake.verifyAuthArgsForCall)
+}
+
+func (fake *FakeBoshClient) VerifyAuthCalls(stub func(*log.Logger) error) {
+	fake.verifyAuthMutex.Lock()
+	defer fake.verifyAuthMutex.Unlock()
+	fake.VerifyAuthStub = stub
+}
+
+func (fake *FakeBoshClient) VerifyAuthArgsForCall(i int) *log.Logger {
+	fake.verifyAuthMutex.RLock()
+	defer fake.verifyAuthMutex.RUnlock()
+	argsForCall := fake.verifyAuthArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeBoshClient) VerifyAuthReturns(result1 error) {
+	fake.verifyAuthMutex.Lock()
+	defer fake.verifyAuthMutex.Unlock()
+	fake.VerifyAuthStub = nil
+	fake.verifyAuthReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBoshClient) VerifyAuthReturnsOnCall(i int, result1 error) {
+	fake.verifyAuthMutex.Lock()
+	defer fake.verifyAuthMutex.Unlock()
+	fake.VerifyAuthStub = nil
+	if fake.verifyAuthReturnsOnCall == nil {
+		fake.verifyAuthReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.verifyAuthReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeBoshClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getTaskMutex.RLock()
-	defer fake.getTaskMutex.RUnlock()
-	fake.getTasksMutex.RLock()
-	defer fake.getTasksMutex.RUnlock()
-	fake.getNormalisedTasksByContextMutex.RLock()
-	defer fake.getNormalisedTasksByContextMutex.RUnlock()
-	fake.vMsMutex.RLock()
-	defer fake.vMsMutex.RUnlock()
+	fake.deleteConfigMutex.RLock()
+	defer fake.deleteConfigMutex.RUnlock()
+	fake.deleteDeploymentMutex.RLock()
+	defer fake.deleteDeploymentMutex.RUnlock()
+	fake.deployMutex.RLock()
+	defer fake.deployMutex.RUnlock()
+	fake.getConfigsMutex.RLock()
+	defer fake.getConfigsMutex.RUnlock()
+	fake.getDNSAddressesMutex.RLock()
+	defer fake.getDNSAddressesMutex.RUnlock()
 	fake.getDeploymentMutex.RLock()
 	defer fake.getDeploymentMutex.RUnlock()
 	fake.getDeploymentsMutex.RLock()
 	defer fake.getDeploymentsMutex.RUnlock()
-	fake.deleteDeploymentMutex.RLock()
-	defer fake.deleteDeploymentMutex.RUnlock()
 	fake.getInfoMutex.RLock()
 	defer fake.getInfoMutex.RUnlock()
+	fake.getNormalisedTasksByContextMutex.RLock()
+	defer fake.getNormalisedTasksByContextMutex.RUnlock()
+	fake.getTaskMutex.RLock()
+	defer fake.getTaskMutex.RUnlock()
+	fake.getTasksMutex.RLock()
+	defer fake.getTasksMutex.RUnlock()
+	fake.recreateMutex.RLock()
+	defer fake.recreateMutex.RUnlock()
 	fake.runErrandMutex.RLock()
 	defer fake.runErrandMutex.RUnlock()
+	fake.updateConfigMutex.RLock()
+	defer fake.updateConfigMutex.RUnlock()
+	fake.vMsMutex.RLock()
+	defer fake.vMsMutex.RUnlock()
 	fake.variablesMutex.RLock()
 	defer fake.variablesMutex.RUnlock()
 	fake.verifyAuthMutex.RLock()
 	defer fake.verifyAuthMutex.RUnlock()
-	fake.getDNSAddressesMutex.RLock()
-	defer fake.getDNSAddressesMutex.RUnlock()
-	fake.deployMutex.RLock()
-	defer fake.deployMutex.RUnlock()
-	fake.recreateMutex.RLock()
-	defer fake.recreateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/broker/lifecycle_runner.go
+++ b/broker/lifecycle_runner.go
@@ -148,3 +148,20 @@ func (l LifeCycleRunner) runErrand(deploymentName, errand string, errandInstance
 
 	return task, nil
 }
+
+func (l LifeCycleRunner) ProcessPostDelete(deploymentName string, log *log.Logger) error {
+	configs, err := l.boshClient.GetConfigs(deploymentName, log)
+	if err != nil {
+		return err
+	}
+
+	for _, config := range configs {
+		_, err := l.boshClient.DeleteConfig(config.Type, config.Name, log)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}

--- a/broker/lifecycle_runner_test.go
+++ b/broker/lifecycle_runner_test.go
@@ -478,4 +478,60 @@ var _ = Describe("Lifecycle runner", func() {
 			Expect(task).To(Equal(taskComplete))
 		})
 	})
+
+	Describe("post-delete", func() {
+		Context("when there are bosh configs", func() {
+			BeforeEach(func() {
+				boshClient.GetConfigsReturns([]boshdirector.BoshConfig{
+					boshdirector.BoshConfig{
+						Type: "some-config-type",
+						Name: "some-config-name",
+					},
+				}, nil)
+			})
+
+			It("deletes bosh configs", func() {
+				err := deployRunner.ProcessPostDelete(deploymentName, logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(boshClient.DeleteConfigCallCount()).To(Equal(1))
+				configType, configName, _ := boshClient.DeleteConfigArgsForCall(0)
+				Expect(configType).To(Equal("some-config-type"))
+				Expect(configName).To(Equal("some-config-name"))
+			})
+
+			Context("when there is an error deleting a config", func() {
+				BeforeEach(func() {
+					boshClient.DeleteConfigReturns(false, errors.New("some-err"))
+				})
+
+				It("returns the error", func() {
+					err := deployRunner.ProcessPostDelete(deploymentName, logger)
+					Expect(err).To(MatchError("some-err"))
+				})
+			})
+		})
+
+		Context("when there are not any bosh configs", func() {
+			BeforeEach(func() {
+				boshClient.GetConfigsReturns([]boshdirector.BoshConfig{}, nil)
+			})
+
+			It("does not delete any config", func() {
+				err := deployRunner.ProcessPostDelete(deploymentName, logger)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(boshClient.DeleteConfigCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("when there is an error getting bosh configs", func() {
+			BeforeEach(func() {
+				boshClient.GetConfigsReturns([]boshdirector.BoshConfig{}, errors.New("some-err"))
+			})
+
+			It("returns the error", func() {
+				err := deployRunner.ProcessPostDelete(deploymentName, logger)
+				Expect(err).To(MatchError("some-err"))
+			})
+		})
+	})
 })

--- a/integration_tests/on_demand_service_broker/mock/adapter/main.go
+++ b/integration_tests/on_demand_service_broker/mock/adapter/main.go
@@ -59,7 +59,8 @@ func (a *Adapter) GenerateManifest(
 	requestParams serviceadapter.RequestParameters,
 	previousManifest *bosh.BoshManifest,
 	previousPlan *serviceadapter.Plan,
-	previousSecret serviceadapter.ManifestSecrets) (serviceadapter.GenerateManifestOutput, error) {
+	previousSecret serviceadapter.ManifestSecrets,
+	previousConfigs serviceadapter.BOSHConfigs) (serviceadapter.GenerateManifestOutput, error) {
 
 	errorMessageForOperator := os.Getenv(mock.StderrContentForGenerate)
 	if errorMessageForOperator != "" {

--- a/serviceadapter/generate_manifest.go
+++ b/serviceadapter/generate_manifest.go
@@ -37,6 +37,7 @@ func (c *Client) GenerateManifest(
 	previousManifest []byte,
 	previousPlan *sdk.Plan,
 	previousSecrets map[string]string,
+	previousConfigs map[string]string,
 	logger *log.Logger,
 ) (sdk.MarshalledGenerateManifest, error) {
 
@@ -68,6 +69,11 @@ func (c *Client) GenerateManifest(
 		return sdk.MarshalledGenerateManifest{}, err
 	}
 
+	serialisedPreviousConfigs, err := json.Marshal(previousConfigs)
+	if err != nil {
+		return sdk.MarshalledGenerateManifest{}, err
+	}
+
 	var stdout, stderr []byte
 	var output sdk.MarshalledGenerateManifest
 	var exitCode *int
@@ -82,6 +88,7 @@ func (c *Client) GenerateManifest(
 				PreviousPlan:      string(serialisedPreviousPlan),
 				PreviousManifest:  string(previousManifest),
 				PreviousSecrets:   string(serialisedPreviousSecrets),
+				PreviousConfigs:   string(serialisedPreviousConfigs),
 			},
 		}
 		stdout, stderr, exitCode, err = c.CommandRunner.RunWithInputParams(

--- a/serviceadapter/generate_manifest_test.go
+++ b/serviceadapter/generate_manifest_test.go
@@ -33,6 +33,9 @@ var _ = Describe("external service adapter", func() {
 		ODBManagedSecrets: map[string]interface{}{
 			"pirate_status": "noob",
 		},
+		Configs: map[string]string{
+			"some-config-type": "some-config-content",
+		},
 	}
 
 	var (
@@ -46,6 +49,7 @@ var _ = Describe("external service adapter", func() {
 		params            map[string]interface{}
 		previousManifest  []byte
 		previousSecrets   map[string]string
+		previousConfigs   map[string]string
 
 		inputParams sdk.InputParams
 
@@ -99,6 +103,7 @@ var _ = Describe("external service adapter", func() {
 			},
 		}
 		previousSecrets = map[string]string{"sup": "yeah!"}
+		previousConfigs = map[string]string{"some-config-type": "some-config-content"}
 
 		inputParams = sdk.InputParams{
 			GenerateManifest: sdk.GenerateManifestParams{
@@ -108,13 +113,14 @@ var _ = Describe("external service adapter", func() {
 				PreviousManifest:  string(previousManifest),
 				RequestParameters: toJson(params),
 				PreviousSecrets:   toJson(previousSecrets),
+				PreviousConfigs:   toJson(previousConfigs),
 			},
 		}
 
 	})
 
 	JustBeforeEach(func() {
-		generateManifestOutput, generateErr = a.GenerateManifest(serviceDeployment, plan, params, previousManifest, previousPlan, previousSecrets, logger)
+		generateManifestOutput, generateErr = a.GenerateManifest(serviceDeployment, plan, params, previousManifest, previousPlan, previousSecrets, previousConfigs, logger)
 	})
 
 	It("invokes external manifest generator with serialised parameters when 'UsingStdin' not set", func() {
@@ -150,6 +156,9 @@ var _ = Describe("external service adapter", func() {
 
 				By("not setting the secrets")
 				Expect(generateManifestOutput.ODBManagedSecrets).To(BeEmpty())
+
+				By("not setting the configs")
+				Expect(generateManifestOutput.Configs).To(BeEmpty())
 			})
 		})
 
@@ -293,6 +302,9 @@ stemcells:
 
 					By("setting the secrets")
 					Expect(generateManifestOutput.ODBManagedSecrets).To(Equal(expectedGenerateManifestOutput.ODBManagedSecrets))
+
+					By("setting the configs")
+					Expect(generateManifestOutput.Configs).To(Equal(expectedGenerateManifestOutput.Configs))
 				})
 			})
 

--- a/task/fakes/fake_bosh_client.go
+++ b/task/fakes/fake_bosh_client.go
@@ -2,21 +2,21 @@
 package fakes
 
 import (
-	"log"
-	"sync"
+	log "log"
+	sync "sync"
 
-	"github.com/pivotal-cf/on-demand-service-broker/boshdirector"
-	"github.com/pivotal-cf/on-demand-service-broker/task"
+	boshdirector "github.com/pivotal-cf/on-demand-service-broker/boshdirector"
+	task "github.com/pivotal-cf/on-demand-service-broker/task"
 )
 
 type FakeBoshClient struct {
-	DeployStub        func(manifest []byte, contextID string, logger *log.Logger, reporter *boshdirector.AsyncTaskReporter) (int, error)
+	DeployStub        func([]byte, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)
 	deployMutex       sync.RWMutex
 	deployArgsForCall []struct {
-		manifest  []byte
-		contextID string
-		logger    *log.Logger
-		reporter  *boshdirector.AsyncTaskReporter
+		arg1 []byte
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
 	}
 	deployReturns struct {
 		result1 int
@@ -26,41 +26,25 @@ type FakeBoshClient struct {
 		result1 int
 		result2 error
 	}
-	RecreateStub        func(deploymentName, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error)
-	recreateMutex       sync.RWMutex
-	recreateArgsForCall []struct {
-		deploymentName string
-		contextID      string
-		logger         *log.Logger
-		taskReporter   *boshdirector.AsyncTaskReporter
+	GetConfigsStub        func(string, *log.Logger) ([]boshdirector.BoshConfig, error)
+	getConfigsMutex       sync.RWMutex
+	getConfigsArgsForCall []struct {
+		arg1 string
+		arg2 *log.Logger
 	}
-	recreateReturns struct {
-		result1 int
+	getConfigsReturns struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}
-	recreateReturnsOnCall map[int]struct {
-		result1 int
+	getConfigsReturnsOnCall map[int]struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}
-	GetTasksStub        func(deploymentName string, logger *log.Logger) (boshdirector.BoshTasks, error)
-	getTasksMutex       sync.RWMutex
-	getTasksArgsForCall []struct {
-		deploymentName string
-		logger         *log.Logger
-	}
-	getTasksReturns struct {
-		result1 boshdirector.BoshTasks
-		result2 error
-	}
-	getTasksReturnsOnCall map[int]struct {
-		result1 boshdirector.BoshTasks
-		result2 error
-	}
-	GetDeploymentStub        func(name string, logger *log.Logger) ([]byte, bool, error)
+	GetDeploymentStub        func(string, *log.Logger) ([]byte, bool, error)
 	getDeploymentMutex       sync.RWMutex
 	getDeploymentArgsForCall []struct {
-		name   string
-		logger *log.Logger
+		arg1 string
+		arg2 *log.Logger
 	}
 	getDeploymentReturns struct {
 		result1 []byte
@@ -72,33 +56,78 @@ type FakeBoshClient struct {
 		result2 bool
 		result3 error
 	}
+	GetTasksStub        func(string, *log.Logger) (boshdirector.BoshTasks, error)
+	getTasksMutex       sync.RWMutex
+	getTasksArgsForCall []struct {
+		arg1 string
+		arg2 *log.Logger
+	}
+	getTasksReturns struct {
+		result1 boshdirector.BoshTasks
+		result2 error
+	}
+	getTasksReturnsOnCall map[int]struct {
+		result1 boshdirector.BoshTasks
+		result2 error
+	}
+	RecreateStub        func(string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)
+	recreateMutex       sync.RWMutex
+	recreateArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
+	}
+	recreateReturns struct {
+		result1 int
+		result2 error
+	}
+	recreateReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
+	UpdateConfigStub        func(string, string, []byte, *log.Logger) error
+	updateConfigMutex       sync.RWMutex
+	updateConfigArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 []byte
+		arg4 *log.Logger
+	}
+	updateConfigReturns struct {
+		result1 error
+	}
+	updateConfigReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeBoshClient) Deploy(manifest []byte, contextID string, logger *log.Logger, reporter *boshdirector.AsyncTaskReporter) (int, error) {
-	var manifestCopy []byte
-	if manifest != nil {
-		manifestCopy = make([]byte, len(manifest))
-		copy(manifestCopy, manifest)
+func (fake *FakeBoshClient) Deploy(arg1 []byte, arg2 string, arg3 *log.Logger, arg4 *boshdirector.AsyncTaskReporter) (int, error) {
+	var arg1Copy []byte
+	if arg1 != nil {
+		arg1Copy = make([]byte, len(arg1))
+		copy(arg1Copy, arg1)
 	}
 	fake.deployMutex.Lock()
 	ret, specificReturn := fake.deployReturnsOnCall[len(fake.deployArgsForCall)]
 	fake.deployArgsForCall = append(fake.deployArgsForCall, struct {
-		manifest  []byte
-		contextID string
-		logger    *log.Logger
-		reporter  *boshdirector.AsyncTaskReporter
-	}{manifestCopy, contextID, logger, reporter})
-	fake.recordInvocation("Deploy", []interface{}{manifestCopy, contextID, logger, reporter})
+		arg1 []byte
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
+	}{arg1Copy, arg2, arg3, arg4})
+	fake.recordInvocation("Deploy", []interface{}{arg1Copy, arg2, arg3, arg4})
 	fake.deployMutex.Unlock()
 	if fake.DeployStub != nil {
-		return fake.DeployStub(manifest, contextID, logger, reporter)
+		return fake.DeployStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.deployReturns.result1, fake.deployReturns.result2
+	fakeReturns := fake.deployReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeBoshClient) DeployCallCount() int {
@@ -107,13 +136,22 @@ func (fake *FakeBoshClient) DeployCallCount() int {
 	return len(fake.deployArgsForCall)
 }
 
+func (fake *FakeBoshClient) DeployCalls(stub func([]byte, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)) {
+	fake.deployMutex.Lock()
+	defer fake.deployMutex.Unlock()
+	fake.DeployStub = stub
+}
+
 func (fake *FakeBoshClient) DeployArgsForCall(i int) ([]byte, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
 	fake.deployMutex.RLock()
 	defer fake.deployMutex.RUnlock()
-	return fake.deployArgsForCall[i].manifest, fake.deployArgsForCall[i].contextID, fake.deployArgsForCall[i].logger, fake.deployArgsForCall[i].reporter
+	argsForCall := fake.deployArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeBoshClient) DeployReturns(result1 int, result2 error) {
+	fake.deployMutex.Lock()
+	defer fake.deployMutex.Unlock()
 	fake.DeployStub = nil
 	fake.deployReturns = struct {
 		result1 int
@@ -122,6 +160,8 @@ func (fake *FakeBoshClient) DeployReturns(result1 int, result2 error) {
 }
 
 func (fake *FakeBoshClient) DeployReturnsOnCall(i int, result1 int, result2 error) {
+	fake.deployMutex.Lock()
+	defer fake.deployMutex.Unlock()
 	fake.DeployStub = nil
 	if fake.deployReturnsOnCall == nil {
 		fake.deployReturnsOnCall = make(map[int]struct {
@@ -135,128 +175,87 @@ func (fake *FakeBoshClient) DeployReturnsOnCall(i int, result1 int, result2 erro
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) Recreate(deploymentName string, contextID string, logger *log.Logger, taskReporter *boshdirector.AsyncTaskReporter) (int, error) {
-	fake.recreateMutex.Lock()
-	ret, specificReturn := fake.recreateReturnsOnCall[len(fake.recreateArgsForCall)]
-	fake.recreateArgsForCall = append(fake.recreateArgsForCall, struct {
-		deploymentName string
-		contextID      string
-		logger         *log.Logger
-		taskReporter   *boshdirector.AsyncTaskReporter
-	}{deploymentName, contextID, logger, taskReporter})
-	fake.recordInvocation("Recreate", []interface{}{deploymentName, contextID, logger, taskReporter})
-	fake.recreateMutex.Unlock()
-	if fake.RecreateStub != nil {
-		return fake.RecreateStub(deploymentName, contextID, logger, taskReporter)
+func (fake *FakeBoshClient) GetConfigs(arg1 string, arg2 *log.Logger) ([]boshdirector.BoshConfig, error) {
+	fake.getConfigsMutex.Lock()
+	ret, specificReturn := fake.getConfigsReturnsOnCall[len(fake.getConfigsArgsForCall)]
+	fake.getConfigsArgsForCall = append(fake.getConfigsArgsForCall, struct {
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GetConfigs", []interface{}{arg1, arg2})
+	fake.getConfigsMutex.Unlock()
+	if fake.GetConfigsStub != nil {
+		return fake.GetConfigsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.recreateReturns.result1, fake.recreateReturns.result2
+	fakeReturns := fake.getConfigsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeBoshClient) RecreateCallCount() int {
-	fake.recreateMutex.RLock()
-	defer fake.recreateMutex.RUnlock()
-	return len(fake.recreateArgsForCall)
+func (fake *FakeBoshClient) GetConfigsCallCount() int {
+	fake.getConfigsMutex.RLock()
+	defer fake.getConfigsMutex.RUnlock()
+	return len(fake.getConfigsArgsForCall)
 }
 
-func (fake *FakeBoshClient) RecreateArgsForCall(i int) (string, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
-	fake.recreateMutex.RLock()
-	defer fake.recreateMutex.RUnlock()
-	return fake.recreateArgsForCall[i].deploymentName, fake.recreateArgsForCall[i].contextID, fake.recreateArgsForCall[i].logger, fake.recreateArgsForCall[i].taskReporter
+func (fake *FakeBoshClient) GetConfigsCalls(stub func(string, *log.Logger) ([]boshdirector.BoshConfig, error)) {
+	fake.getConfigsMutex.Lock()
+	defer fake.getConfigsMutex.Unlock()
+	fake.GetConfigsStub = stub
 }
 
-func (fake *FakeBoshClient) RecreateReturns(result1 int, result2 error) {
-	fake.RecreateStub = nil
-	fake.recreateReturns = struct {
-		result1 int
+func (fake *FakeBoshClient) GetConfigsArgsForCall(i int) (string, *log.Logger) {
+	fake.getConfigsMutex.RLock()
+	defer fake.getConfigsMutex.RUnlock()
+	argsForCall := fake.getConfigsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) GetConfigsReturns(result1 []boshdirector.BoshConfig, result2 error) {
+	fake.getConfigsMutex.Lock()
+	defer fake.getConfigsMutex.Unlock()
+	fake.GetConfigsStub = nil
+	fake.getConfigsReturns = struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) RecreateReturnsOnCall(i int, result1 int, result2 error) {
-	fake.RecreateStub = nil
-	if fake.recreateReturnsOnCall == nil {
-		fake.recreateReturnsOnCall = make(map[int]struct {
-			result1 int
+func (fake *FakeBoshClient) GetConfigsReturnsOnCall(i int, result1 []boshdirector.BoshConfig, result2 error) {
+	fake.getConfigsMutex.Lock()
+	defer fake.getConfigsMutex.Unlock()
+	fake.GetConfigsStub = nil
+	if fake.getConfigsReturnsOnCall == nil {
+		fake.getConfigsReturnsOnCall = make(map[int]struct {
+			result1 []boshdirector.BoshConfig
 			result2 error
 		})
 	}
-	fake.recreateReturnsOnCall[i] = struct {
-		result1 int
+	fake.getConfigsReturnsOnCall[i] = struct {
+		result1 []boshdirector.BoshConfig
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeBoshClient) GetTasks(deploymentName string, logger *log.Logger) (boshdirector.BoshTasks, error) {
-	fake.getTasksMutex.Lock()
-	ret, specificReturn := fake.getTasksReturnsOnCall[len(fake.getTasksArgsForCall)]
-	fake.getTasksArgsForCall = append(fake.getTasksArgsForCall, struct {
-		deploymentName string
-		logger         *log.Logger
-	}{deploymentName, logger})
-	fake.recordInvocation("GetTasks", []interface{}{deploymentName, logger})
-	fake.getTasksMutex.Unlock()
-	if fake.GetTasksStub != nil {
-		return fake.GetTasksStub(deploymentName, logger)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.getTasksReturns.result1, fake.getTasksReturns.result2
-}
-
-func (fake *FakeBoshClient) GetTasksCallCount() int {
-	fake.getTasksMutex.RLock()
-	defer fake.getTasksMutex.RUnlock()
-	return len(fake.getTasksArgsForCall)
-}
-
-func (fake *FakeBoshClient) GetTasksArgsForCall(i int) (string, *log.Logger) {
-	fake.getTasksMutex.RLock()
-	defer fake.getTasksMutex.RUnlock()
-	return fake.getTasksArgsForCall[i].deploymentName, fake.getTasksArgsForCall[i].logger
-}
-
-func (fake *FakeBoshClient) GetTasksReturns(result1 boshdirector.BoshTasks, result2 error) {
-	fake.GetTasksStub = nil
-	fake.getTasksReturns = struct {
-		result1 boshdirector.BoshTasks
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeBoshClient) GetTasksReturnsOnCall(i int, result1 boshdirector.BoshTasks, result2 error) {
-	fake.GetTasksStub = nil
-	if fake.getTasksReturnsOnCall == nil {
-		fake.getTasksReturnsOnCall = make(map[int]struct {
-			result1 boshdirector.BoshTasks
-			result2 error
-		})
-	}
-	fake.getTasksReturnsOnCall[i] = struct {
-		result1 boshdirector.BoshTasks
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeBoshClient) GetDeployment(name string, logger *log.Logger) ([]byte, bool, error) {
+func (fake *FakeBoshClient) GetDeployment(arg1 string, arg2 *log.Logger) ([]byte, bool, error) {
 	fake.getDeploymentMutex.Lock()
 	ret, specificReturn := fake.getDeploymentReturnsOnCall[len(fake.getDeploymentArgsForCall)]
 	fake.getDeploymentArgsForCall = append(fake.getDeploymentArgsForCall, struct {
-		name   string
-		logger *log.Logger
-	}{name, logger})
-	fake.recordInvocation("GetDeployment", []interface{}{name, logger})
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GetDeployment", []interface{}{arg1, arg2})
 	fake.getDeploymentMutex.Unlock()
 	if fake.GetDeploymentStub != nil {
-		return fake.GetDeploymentStub(name, logger)
+		return fake.GetDeploymentStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.getDeploymentReturns.result1, fake.getDeploymentReturns.result2, fake.getDeploymentReturns.result3
+	fakeReturns := fake.getDeploymentReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeBoshClient) GetDeploymentCallCount() int {
@@ -265,13 +264,22 @@ func (fake *FakeBoshClient) GetDeploymentCallCount() int {
 	return len(fake.getDeploymentArgsForCall)
 }
 
+func (fake *FakeBoshClient) GetDeploymentCalls(stub func(string, *log.Logger) ([]byte, bool, error)) {
+	fake.getDeploymentMutex.Lock()
+	defer fake.getDeploymentMutex.Unlock()
+	fake.GetDeploymentStub = stub
+}
+
 func (fake *FakeBoshClient) GetDeploymentArgsForCall(i int) (string, *log.Logger) {
 	fake.getDeploymentMutex.RLock()
 	defer fake.getDeploymentMutex.RUnlock()
-	return fake.getDeploymentArgsForCall[i].name, fake.getDeploymentArgsForCall[i].logger
+	argsForCall := fake.getDeploymentArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeBoshClient) GetDeploymentReturns(result1 []byte, result2 bool, result3 error) {
+	fake.getDeploymentMutex.Lock()
+	defer fake.getDeploymentMutex.Unlock()
 	fake.GetDeploymentStub = nil
 	fake.getDeploymentReturns = struct {
 		result1 []byte
@@ -281,6 +289,8 @@ func (fake *FakeBoshClient) GetDeploymentReturns(result1 []byte, result2 bool, r
 }
 
 func (fake *FakeBoshClient) GetDeploymentReturnsOnCall(i int, result1 []byte, result2 bool, result3 error) {
+	fake.getDeploymentMutex.Lock()
+	defer fake.getDeploymentMutex.Unlock()
 	fake.GetDeploymentStub = nil
 	if fake.getDeploymentReturnsOnCall == nil {
 		fake.getDeploymentReturnsOnCall = make(map[int]struct {
@@ -296,17 +306,219 @@ func (fake *FakeBoshClient) GetDeploymentReturnsOnCall(i int, result1 []byte, re
 	}{result1, result2, result3}
 }
 
+func (fake *FakeBoshClient) GetTasks(arg1 string, arg2 *log.Logger) (boshdirector.BoshTasks, error) {
+	fake.getTasksMutex.Lock()
+	ret, specificReturn := fake.getTasksReturnsOnCall[len(fake.getTasksArgsForCall)]
+	fake.getTasksArgsForCall = append(fake.getTasksArgsForCall, struct {
+		arg1 string
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GetTasks", []interface{}{arg1, arg2})
+	fake.getTasksMutex.Unlock()
+	if fake.GetTasksStub != nil {
+		return fake.GetTasksStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getTasksReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBoshClient) GetTasksCallCount() int {
+	fake.getTasksMutex.RLock()
+	defer fake.getTasksMutex.RUnlock()
+	return len(fake.getTasksArgsForCall)
+}
+
+func (fake *FakeBoshClient) GetTasksCalls(stub func(string, *log.Logger) (boshdirector.BoshTasks, error)) {
+	fake.getTasksMutex.Lock()
+	defer fake.getTasksMutex.Unlock()
+	fake.GetTasksStub = stub
+}
+
+func (fake *FakeBoshClient) GetTasksArgsForCall(i int) (string, *log.Logger) {
+	fake.getTasksMutex.RLock()
+	defer fake.getTasksMutex.RUnlock()
+	argsForCall := fake.getTasksArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeBoshClient) GetTasksReturns(result1 boshdirector.BoshTasks, result2 error) {
+	fake.getTasksMutex.Lock()
+	defer fake.getTasksMutex.Unlock()
+	fake.GetTasksStub = nil
+	fake.getTasksReturns = struct {
+		result1 boshdirector.BoshTasks
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) GetTasksReturnsOnCall(i int, result1 boshdirector.BoshTasks, result2 error) {
+	fake.getTasksMutex.Lock()
+	defer fake.getTasksMutex.Unlock()
+	fake.GetTasksStub = nil
+	if fake.getTasksReturnsOnCall == nil {
+		fake.getTasksReturnsOnCall = make(map[int]struct {
+			result1 boshdirector.BoshTasks
+			result2 error
+		})
+	}
+	fake.getTasksReturnsOnCall[i] = struct {
+		result1 boshdirector.BoshTasks
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) Recreate(arg1 string, arg2 string, arg3 *log.Logger, arg4 *boshdirector.AsyncTaskReporter) (int, error) {
+	fake.recreateMutex.Lock()
+	ret, specificReturn := fake.recreateReturnsOnCall[len(fake.recreateArgsForCall)]
+	fake.recreateArgsForCall = append(fake.recreateArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 *log.Logger
+		arg4 *boshdirector.AsyncTaskReporter
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("Recreate", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recreateMutex.Unlock()
+	if fake.RecreateStub != nil {
+		return fake.RecreateStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.recreateReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeBoshClient) RecreateCallCount() int {
+	fake.recreateMutex.RLock()
+	defer fake.recreateMutex.RUnlock()
+	return len(fake.recreateArgsForCall)
+}
+
+func (fake *FakeBoshClient) RecreateCalls(stub func(string, string, *log.Logger, *boshdirector.AsyncTaskReporter) (int, error)) {
+	fake.recreateMutex.Lock()
+	defer fake.recreateMutex.Unlock()
+	fake.RecreateStub = stub
+}
+
+func (fake *FakeBoshClient) RecreateArgsForCall(i int) (string, string, *log.Logger, *boshdirector.AsyncTaskReporter) {
+	fake.recreateMutex.RLock()
+	defer fake.recreateMutex.RUnlock()
+	argsForCall := fake.recreateArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeBoshClient) RecreateReturns(result1 int, result2 error) {
+	fake.recreateMutex.Lock()
+	defer fake.recreateMutex.Unlock()
+	fake.RecreateStub = nil
+	fake.recreateReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) RecreateReturnsOnCall(i int, result1 int, result2 error) {
+	fake.recreateMutex.Lock()
+	defer fake.recreateMutex.Unlock()
+	fake.RecreateStub = nil
+	if fake.recreateReturnsOnCall == nil {
+		fake.recreateReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.recreateReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeBoshClient) UpdateConfig(arg1 string, arg2 string, arg3 []byte, arg4 *log.Logger) error {
+	var arg3Copy []byte
+	if arg3 != nil {
+		arg3Copy = make([]byte, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.updateConfigMutex.Lock()
+	ret, specificReturn := fake.updateConfigReturnsOnCall[len(fake.updateConfigArgsForCall)]
+	fake.updateConfigArgsForCall = append(fake.updateConfigArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 []byte
+		arg4 *log.Logger
+	}{arg1, arg2, arg3Copy, arg4})
+	fake.recordInvocation("UpdateConfig", []interface{}{arg1, arg2, arg3Copy, arg4})
+	fake.updateConfigMutex.Unlock()
+	if fake.UpdateConfigStub != nil {
+		return fake.UpdateConfigStub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.updateConfigReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeBoshClient) UpdateConfigCallCount() int {
+	fake.updateConfigMutex.RLock()
+	defer fake.updateConfigMutex.RUnlock()
+	return len(fake.updateConfigArgsForCall)
+}
+
+func (fake *FakeBoshClient) UpdateConfigCalls(stub func(string, string, []byte, *log.Logger) error) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = stub
+}
+
+func (fake *FakeBoshClient) UpdateConfigArgsForCall(i int) (string, string, []byte, *log.Logger) {
+	fake.updateConfigMutex.RLock()
+	defer fake.updateConfigMutex.RUnlock()
+	argsForCall := fake.updateConfigArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeBoshClient) UpdateConfigReturns(result1 error) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = nil
+	fake.updateConfigReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeBoshClient) UpdateConfigReturnsOnCall(i int, result1 error) {
+	fake.updateConfigMutex.Lock()
+	defer fake.updateConfigMutex.Unlock()
+	fake.UpdateConfigStub = nil
+	if fake.updateConfigReturnsOnCall == nil {
+		fake.updateConfigReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeBoshClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.deployMutex.RLock()
 	defer fake.deployMutex.RUnlock()
-	fake.recreateMutex.RLock()
-	defer fake.recreateMutex.RUnlock()
-	fake.getTasksMutex.RLock()
-	defer fake.getTasksMutex.RUnlock()
+	fake.getConfigsMutex.RLock()
+	defer fake.getConfigsMutex.RUnlock()
 	fake.getDeploymentMutex.RLock()
 	defer fake.getDeploymentMutex.RUnlock()
+	fake.getTasksMutex.RLock()
+	defer fake.getTasksMutex.RUnlock()
+	fake.recreateMutex.RLock()
+	defer fake.recreateMutex.RUnlock()
+	fake.updateConfigMutex.RLock()
+	defer fake.updateConfigMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/task/fakes/fake_manifest_generator.go
+++ b/task/fakes/fake_manifest_generator.go
@@ -2,24 +2,25 @@
 package fakes
 
 import (
-	"log"
-	"sync"
+	log "log"
+	sync "sync"
 
-	"github.com/pivotal-cf/on-demand-service-broker/task"
-	"github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
+	task "github.com/pivotal-cf/on-demand-service-broker/task"
+	serviceadapter "github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
 )
 
 type FakeManifestGenerator struct {
-	GenerateManifestStub        func(deploymentName, planID string, requestParams map[string]interface{}, oldManifest []byte, previousPlanID *string, secretsMap map[string]string, logger *log.Logger) (serviceadapter.MarshalledGenerateManifest, error)
+	GenerateManifestStub        func(string, string, map[string]interface{}, []byte, *string, map[string]string, map[string]string, *log.Logger) (serviceadapter.MarshalledGenerateManifest, error)
 	generateManifestMutex       sync.RWMutex
 	generateManifestArgsForCall []struct {
-		deploymentName string
-		planID         string
-		requestParams  map[string]interface{}
-		oldManifest    []byte
-		previousPlanID *string
-		secretsMap     map[string]string
-		logger         *log.Logger
+		arg1 string
+		arg2 string
+		arg3 map[string]interface{}
+		arg4 []byte
+		arg5 *string
+		arg6 map[string]string
+		arg7 map[string]string
+		arg8 *log.Logger
 	}
 	generateManifestReturns struct {
 		result1 serviceadapter.MarshalledGenerateManifest
@@ -33,32 +34,34 @@ type FakeManifestGenerator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeManifestGenerator) GenerateManifest(deploymentName string, planID string, requestParams map[string]interface{}, oldManifest []byte, previousPlanID *string, secretsMap map[string]string, logger *log.Logger) (serviceadapter.MarshalledGenerateManifest, error) {
-	var oldManifestCopy []byte
-	if oldManifest != nil {
-		oldManifestCopy = make([]byte, len(oldManifest))
-		copy(oldManifestCopy, oldManifest)
+func (fake *FakeManifestGenerator) GenerateManifest(arg1 string, arg2 string, arg3 map[string]interface{}, arg4 []byte, arg5 *string, arg6 map[string]string, arg7 map[string]string, arg8 *log.Logger) (serviceadapter.MarshalledGenerateManifest, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
 	}
 	fake.generateManifestMutex.Lock()
 	ret, specificReturn := fake.generateManifestReturnsOnCall[len(fake.generateManifestArgsForCall)]
 	fake.generateManifestArgsForCall = append(fake.generateManifestArgsForCall, struct {
-		deploymentName string
-		planID         string
-		requestParams  map[string]interface{}
-		oldManifest    []byte
-		previousPlanID *string
-		secretsMap     map[string]string
-		logger         *log.Logger
-	}{deploymentName, planID, requestParams, oldManifestCopy, previousPlanID, secretsMap, logger})
-	fake.recordInvocation("GenerateManifest", []interface{}{deploymentName, planID, requestParams, oldManifestCopy, previousPlanID, secretsMap, logger})
+		arg1 string
+		arg2 string
+		arg3 map[string]interface{}
+		arg4 []byte
+		arg5 *string
+		arg6 map[string]string
+		arg7 map[string]string
+		arg8 *log.Logger
+	}{arg1, arg2, arg3, arg4Copy, arg5, arg6, arg7, arg8})
+	fake.recordInvocation("GenerateManifest", []interface{}{arg1, arg2, arg3, arg4Copy, arg5, arg6, arg7, arg8})
 	fake.generateManifestMutex.Unlock()
 	if fake.GenerateManifestStub != nil {
-		return fake.GenerateManifestStub(deploymentName, planID, requestParams, oldManifest, previousPlanID, secretsMap, logger)
+		return fake.GenerateManifestStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.generateManifestReturns.result1, fake.generateManifestReturns.result2
+	fakeReturns := fake.generateManifestReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeManifestGenerator) GenerateManifestCallCount() int {
@@ -67,13 +70,22 @@ func (fake *FakeManifestGenerator) GenerateManifestCallCount() int {
 	return len(fake.generateManifestArgsForCall)
 }
 
-func (fake *FakeManifestGenerator) GenerateManifestArgsForCall(i int) (string, string, map[string]interface{}, []byte, *string, map[string]string, *log.Logger) {
+func (fake *FakeManifestGenerator) GenerateManifestCalls(stub func(string, string, map[string]interface{}, []byte, *string, map[string]string, map[string]string, *log.Logger) (serviceadapter.MarshalledGenerateManifest, error)) {
+	fake.generateManifestMutex.Lock()
+	defer fake.generateManifestMutex.Unlock()
+	fake.GenerateManifestStub = stub
+}
+
+func (fake *FakeManifestGenerator) GenerateManifestArgsForCall(i int) (string, string, map[string]interface{}, []byte, *string, map[string]string, map[string]string, *log.Logger) {
 	fake.generateManifestMutex.RLock()
 	defer fake.generateManifestMutex.RUnlock()
-	return fake.generateManifestArgsForCall[i].deploymentName, fake.generateManifestArgsForCall[i].planID, fake.generateManifestArgsForCall[i].requestParams, fake.generateManifestArgsForCall[i].oldManifest, fake.generateManifestArgsForCall[i].previousPlanID, fake.generateManifestArgsForCall[i].secretsMap, fake.generateManifestArgsForCall[i].logger
+	argsForCall := fake.generateManifestArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8
 }
 
 func (fake *FakeManifestGenerator) GenerateManifestReturns(result1 serviceadapter.MarshalledGenerateManifest, result2 error) {
+	fake.generateManifestMutex.Lock()
+	defer fake.generateManifestMutex.Unlock()
 	fake.GenerateManifestStub = nil
 	fake.generateManifestReturns = struct {
 		result1 serviceadapter.MarshalledGenerateManifest
@@ -82,6 +94,8 @@ func (fake *FakeManifestGenerator) GenerateManifestReturns(result1 serviceadapte
 }
 
 func (fake *FakeManifestGenerator) GenerateManifestReturnsOnCall(i int, result1 serviceadapter.MarshalledGenerateManifest, result2 error) {
+	fake.generateManifestMutex.Lock()
+	defer fake.generateManifestMutex.Unlock()
 	fake.GenerateManifestStub = nil
 	if fake.generateManifestReturnsOnCall == nil {
 		fake.generateManifestReturnsOnCall = make(map[int]struct {

--- a/task/fakes/fake_service_adapter_client.go
+++ b/task/fakes/fake_service_adapter_client.go
@@ -2,25 +2,26 @@
 package fakes
 
 import (
-	"log"
-	"sync"
+	log "log"
+	sync "sync"
 
-	"github.com/pivotal-cf/brokerapi"
-	"github.com/pivotal-cf/on-demand-service-broker/task"
-	"github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
+	brokerapi "github.com/pivotal-cf/brokerapi"
+	task "github.com/pivotal-cf/on-demand-service-broker/task"
+	serviceadapter "github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
 )
 
 type FakeServiceAdapterClient struct {
-	GenerateManifestStub        func(serviceReleases serviceadapter.ServiceDeployment, plan serviceadapter.Plan, requestParams map[string]interface{}, previousManifest []byte, previousPlan *serviceadapter.Plan, oldSecretsMap map[string]string, logger *log.Logger) (serviceadapter.MarshalledGenerateManifest, error)
+	GenerateManifestStub        func(serviceadapter.ServiceDeployment, serviceadapter.Plan, map[string]interface{}, []byte, *serviceadapter.Plan, map[string]string, map[string]string, *log.Logger) (serviceadapter.MarshalledGenerateManifest, error)
 	generateManifestMutex       sync.RWMutex
 	generateManifestArgsForCall []struct {
-		serviceReleases  serviceadapter.ServiceDeployment
-		plan             serviceadapter.Plan
-		requestParams    map[string]interface{}
-		previousManifest []byte
-		previousPlan     *serviceadapter.Plan
-		oldSecretsMap    map[string]string
-		logger           *log.Logger
+		arg1 serviceadapter.ServiceDeployment
+		arg2 serviceadapter.Plan
+		arg3 map[string]interface{}
+		arg4 []byte
+		arg5 *serviceadapter.Plan
+		arg6 map[string]string
+		arg7 map[string]string
+		arg8 *log.Logger
 	}
 	generateManifestReturns struct {
 		result1 serviceadapter.MarshalledGenerateManifest
@@ -30,11 +31,11 @@ type FakeServiceAdapterClient struct {
 		result1 serviceadapter.MarshalledGenerateManifest
 		result2 error
 	}
-	GeneratePlanSchemaStub        func(plan serviceadapter.Plan, logger *log.Logger) (brokerapi.ServiceSchemas, error)
+	GeneratePlanSchemaStub        func(serviceadapter.Plan, *log.Logger) (brokerapi.ServiceSchemas, error)
 	generatePlanSchemaMutex       sync.RWMutex
 	generatePlanSchemaArgsForCall []struct {
-		plan   serviceadapter.Plan
-		logger *log.Logger
+		arg1 serviceadapter.Plan
+		arg2 *log.Logger
 	}
 	generatePlanSchemaReturns struct {
 		result1 brokerapi.ServiceSchemas
@@ -48,32 +49,34 @@ type FakeServiceAdapterClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeServiceAdapterClient) GenerateManifest(serviceReleases serviceadapter.ServiceDeployment, plan serviceadapter.Plan, requestParams map[string]interface{}, previousManifest []byte, previousPlan *serviceadapter.Plan, oldSecretsMap map[string]string, logger *log.Logger) (serviceadapter.MarshalledGenerateManifest, error) {
-	var previousManifestCopy []byte
-	if previousManifest != nil {
-		previousManifestCopy = make([]byte, len(previousManifest))
-		copy(previousManifestCopy, previousManifest)
+func (fake *FakeServiceAdapterClient) GenerateManifest(arg1 serviceadapter.ServiceDeployment, arg2 serviceadapter.Plan, arg3 map[string]interface{}, arg4 []byte, arg5 *serviceadapter.Plan, arg6 map[string]string, arg7 map[string]string, arg8 *log.Logger) (serviceadapter.MarshalledGenerateManifest, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
 	}
 	fake.generateManifestMutex.Lock()
 	ret, specificReturn := fake.generateManifestReturnsOnCall[len(fake.generateManifestArgsForCall)]
 	fake.generateManifestArgsForCall = append(fake.generateManifestArgsForCall, struct {
-		serviceReleases  serviceadapter.ServiceDeployment
-		plan             serviceadapter.Plan
-		requestParams    map[string]interface{}
-		previousManifest []byte
-		previousPlan     *serviceadapter.Plan
-		oldSecretsMap    map[string]string
-		logger           *log.Logger
-	}{serviceReleases, plan, requestParams, previousManifestCopy, previousPlan, oldSecretsMap, logger})
-	fake.recordInvocation("GenerateManifest", []interface{}{serviceReleases, plan, requestParams, previousManifestCopy, previousPlan, oldSecretsMap, logger})
+		arg1 serviceadapter.ServiceDeployment
+		arg2 serviceadapter.Plan
+		arg3 map[string]interface{}
+		arg4 []byte
+		arg5 *serviceadapter.Plan
+		arg6 map[string]string
+		arg7 map[string]string
+		arg8 *log.Logger
+	}{arg1, arg2, arg3, arg4Copy, arg5, arg6, arg7, arg8})
+	fake.recordInvocation("GenerateManifest", []interface{}{arg1, arg2, arg3, arg4Copy, arg5, arg6, arg7, arg8})
 	fake.generateManifestMutex.Unlock()
 	if fake.GenerateManifestStub != nil {
-		return fake.GenerateManifestStub(serviceReleases, plan, requestParams, previousManifest, previousPlan, oldSecretsMap, logger)
+		return fake.GenerateManifestStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.generateManifestReturns.result1, fake.generateManifestReturns.result2
+	fakeReturns := fake.generateManifestReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeServiceAdapterClient) GenerateManifestCallCount() int {
@@ -82,13 +85,22 @@ func (fake *FakeServiceAdapterClient) GenerateManifestCallCount() int {
 	return len(fake.generateManifestArgsForCall)
 }
 
-func (fake *FakeServiceAdapterClient) GenerateManifestArgsForCall(i int) (serviceadapter.ServiceDeployment, serviceadapter.Plan, map[string]interface{}, []byte, *serviceadapter.Plan, map[string]string, *log.Logger) {
+func (fake *FakeServiceAdapterClient) GenerateManifestCalls(stub func(serviceadapter.ServiceDeployment, serviceadapter.Plan, map[string]interface{}, []byte, *serviceadapter.Plan, map[string]string, map[string]string, *log.Logger) (serviceadapter.MarshalledGenerateManifest, error)) {
+	fake.generateManifestMutex.Lock()
+	defer fake.generateManifestMutex.Unlock()
+	fake.GenerateManifestStub = stub
+}
+
+func (fake *FakeServiceAdapterClient) GenerateManifestArgsForCall(i int) (serviceadapter.ServiceDeployment, serviceadapter.Plan, map[string]interface{}, []byte, *serviceadapter.Plan, map[string]string, map[string]string, *log.Logger) {
 	fake.generateManifestMutex.RLock()
 	defer fake.generateManifestMutex.RUnlock()
-	return fake.generateManifestArgsForCall[i].serviceReleases, fake.generateManifestArgsForCall[i].plan, fake.generateManifestArgsForCall[i].requestParams, fake.generateManifestArgsForCall[i].previousManifest, fake.generateManifestArgsForCall[i].previousPlan, fake.generateManifestArgsForCall[i].oldSecretsMap, fake.generateManifestArgsForCall[i].logger
+	argsForCall := fake.generateManifestArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6, argsForCall.arg7, argsForCall.arg8
 }
 
 func (fake *FakeServiceAdapterClient) GenerateManifestReturns(result1 serviceadapter.MarshalledGenerateManifest, result2 error) {
+	fake.generateManifestMutex.Lock()
+	defer fake.generateManifestMutex.Unlock()
 	fake.GenerateManifestStub = nil
 	fake.generateManifestReturns = struct {
 		result1 serviceadapter.MarshalledGenerateManifest
@@ -97,6 +109,8 @@ func (fake *FakeServiceAdapterClient) GenerateManifestReturns(result1 serviceada
 }
 
 func (fake *FakeServiceAdapterClient) GenerateManifestReturnsOnCall(i int, result1 serviceadapter.MarshalledGenerateManifest, result2 error) {
+	fake.generateManifestMutex.Lock()
+	defer fake.generateManifestMutex.Unlock()
 	fake.GenerateManifestStub = nil
 	if fake.generateManifestReturnsOnCall == nil {
 		fake.generateManifestReturnsOnCall = make(map[int]struct {
@@ -110,22 +124,23 @@ func (fake *FakeServiceAdapterClient) GenerateManifestReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *FakeServiceAdapterClient) GeneratePlanSchema(plan serviceadapter.Plan, logger *log.Logger) (brokerapi.ServiceSchemas, error) {
+func (fake *FakeServiceAdapterClient) GeneratePlanSchema(arg1 serviceadapter.Plan, arg2 *log.Logger) (brokerapi.ServiceSchemas, error) {
 	fake.generatePlanSchemaMutex.Lock()
 	ret, specificReturn := fake.generatePlanSchemaReturnsOnCall[len(fake.generatePlanSchemaArgsForCall)]
 	fake.generatePlanSchemaArgsForCall = append(fake.generatePlanSchemaArgsForCall, struct {
-		plan   serviceadapter.Plan
-		logger *log.Logger
-	}{plan, logger})
-	fake.recordInvocation("GeneratePlanSchema", []interface{}{plan, logger})
+		arg1 serviceadapter.Plan
+		arg2 *log.Logger
+	}{arg1, arg2})
+	fake.recordInvocation("GeneratePlanSchema", []interface{}{arg1, arg2})
 	fake.generatePlanSchemaMutex.Unlock()
 	if fake.GeneratePlanSchemaStub != nil {
-		return fake.GeneratePlanSchemaStub(plan, logger)
+		return fake.GeneratePlanSchemaStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.generatePlanSchemaReturns.result1, fake.generatePlanSchemaReturns.result2
+	fakeReturns := fake.generatePlanSchemaReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeServiceAdapterClient) GeneratePlanSchemaCallCount() int {
@@ -134,13 +149,22 @@ func (fake *FakeServiceAdapterClient) GeneratePlanSchemaCallCount() int {
 	return len(fake.generatePlanSchemaArgsForCall)
 }
 
+func (fake *FakeServiceAdapterClient) GeneratePlanSchemaCalls(stub func(serviceadapter.Plan, *log.Logger) (brokerapi.ServiceSchemas, error)) {
+	fake.generatePlanSchemaMutex.Lock()
+	defer fake.generatePlanSchemaMutex.Unlock()
+	fake.GeneratePlanSchemaStub = stub
+}
+
 func (fake *FakeServiceAdapterClient) GeneratePlanSchemaArgsForCall(i int) (serviceadapter.Plan, *log.Logger) {
 	fake.generatePlanSchemaMutex.RLock()
 	defer fake.generatePlanSchemaMutex.RUnlock()
-	return fake.generatePlanSchemaArgsForCall[i].plan, fake.generatePlanSchemaArgsForCall[i].logger
+	argsForCall := fake.generatePlanSchemaArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeServiceAdapterClient) GeneratePlanSchemaReturns(result1 brokerapi.ServiceSchemas, result2 error) {
+	fake.generatePlanSchemaMutex.Lock()
+	defer fake.generatePlanSchemaMutex.Unlock()
 	fake.GeneratePlanSchemaStub = nil
 	fake.generatePlanSchemaReturns = struct {
 		result1 brokerapi.ServiceSchemas
@@ -149,6 +173,8 @@ func (fake *FakeServiceAdapterClient) GeneratePlanSchemaReturns(result1 brokerap
 }
 
 func (fake *FakeServiceAdapterClient) GeneratePlanSchemaReturnsOnCall(i int, result1 brokerapi.ServiceSchemas, result2 error) {
+	fake.generatePlanSchemaMutex.Lock()
+	defer fake.generatePlanSchemaMutex.Unlock()
 	fake.GeneratePlanSchemaStub = nil
 	if fake.generatePlanSchemaReturnsOnCall == nil {
 		fake.generatePlanSchemaReturnsOnCall = make(map[int]struct {

--- a/task/manifest_generator.go
+++ b/task/manifest_generator.go
@@ -24,6 +24,7 @@ type ServiceAdapterClient interface {
 		previousManifest []byte,
 		previousPlan *serviceadapter.Plan,
 		oldSecretsMap map[string]string,
+		previousConfigs map[string]string,
 		logger *log.Logger,
 	) (serviceadapter.MarshalledGenerateManifest, error)
 	GeneratePlanSchema(plan serviceadapter.Plan, logger *log.Logger) (brokerapi.ServiceSchemas, error)
@@ -58,6 +59,7 @@ func (m manifestGenerator) GenerateManifest(
 	oldManifest []byte,
 	previousPlanID *string,
 	secretsMap map[string]string,
+	previousConfigs map[string]string,
 	logger *log.Logger,
 ) (serviceadapter.MarshalledGenerateManifest, error) {
 
@@ -74,7 +76,7 @@ func (m manifestGenerator) GenerateManifest(
 	}
 	logger.Printf("service adapter will generate manifest for deployment %s\n", deploymentName)
 
-	manifest, err := m.adapterClient.GenerateManifest(serviceDeployment, plan, requestParams, oldManifest, previousPlan, secretsMap, logger)
+	manifest, err := m.adapterClient.GenerateManifest(serviceDeployment, plan, requestParams, oldManifest, previousPlan, secretsMap, previousConfigs, logger)
 	if err != nil {
 		logger.Printf("generate manifest: %v\n", err)
 	}


### PR DESCRIPTION
This PR adds support for Service Adapters to being able to generate BOSH Configs on-demand.

TODO:
- [ ] Update the [on-demand-services-sdk](https://github.com/pivotal-cf/on-demand-services-sdk) vendored package
- [ ] Update the `system_tests` with proper feature tests