### PR TITLE
Fix listing the configs by returning only the latest configs

### DIFF
--- a/boshdirector/bosh_configs.go
+++ b/boshdirector/bosh_configs.go
@@ -8,10 +8,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	boshConfigsLimit = 30
-)
-
 type BoshConfig struct {
 	Type    string
 	Name    string
@@ -27,7 +23,7 @@ func (c *Client) GetConfigs(configName string, logger *log.Logger) ([]BoshConfig
 		return configs, errors.Wrap(err, "Failed to build director")
 	}
 
-	boshConfigs, err := d.ListConfigs(boshConfigsLimit, director.ConfigsFilter{Name: configName})
+	boshConfigs, err := d.ListConfigs(1, director.ConfigsFilter{Name: configName})
 	if err != nil {
 		return configs, errors.Wrap(err, fmt.Sprintf(`BOSH error getting configs for "%s"`, configName))
 	}
@@ -72,7 +68,7 @@ func (c *Client) DeleteConfigs(configName string, logger *log.Logger) error {
 		return errors.Wrap(err, "Failed to build director")
 	}
 
-	configs, err := d.ListConfigs(boshConfigsLimit, director.ConfigsFilter{Name: configName})
+	configs, err := d.ListConfigs(1, director.ConfigsFilter{Name: configName})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf(`BOSH error getting configs for "%s"`, configName))
 	}

--- a/boshdirector/bosh_configs_test.go
+++ b/boshdirector/bosh_configs_test.go
@@ -64,6 +64,15 @@ var _ = Describe("getting bosh configs", func() {
 			Expect(listConfigsErr).NotTo(HaveOccurred())
 		})
 
+		It("lists the latest configs", func() {
+			fakeDirector.ListConfigsReturns(directorConfigs, nil)
+			c.GetConfigs(configName, logger)
+
+			limit, filter := fakeDirector.ListConfigsArgsForCall(0)
+			Expect(limit).To(Equal(1))
+			Expect(filter).To(Equal(director.ConfigsFilter{Name: configName}))
+		})
+
 		It("returns an error when the director can't be built", func() {
 			fakeDirectorFactory.NewReturns(nil, errors.New("can't get director"))
 			_, listConfigsErr = c.GetConfigs(configName, logger)
@@ -194,6 +203,15 @@ var _ = Describe("deleting bosh configs", func() {
 
 			Expect(deleteConfigsErr).NotTo(HaveOccurred())
 			Expect(fakeDirector.DeleteConfigCallCount()).To(Equal(2))
+		})
+
+		It("lists the latest configs", func() {
+			fakeDirector.ListConfigsReturns(directorConfigs, nil)
+			c.DeleteConfigs(configName, logger)
+
+			limit, filter := fakeDirector.ListConfigsArgsForCall(0)
+			Expect(limit).To(Equal(1))
+			Expect(filter).To(Equal(director.ConfigsFilter{Name: configName}))
 		})
 
 		It("does not delete any config when there are not any bosh configs", func() {


### PR DESCRIPTION
Director [ListConfigs](https://github.com/pivotal-cf/on-demand-service-broker/blob/master/vendor/github.com/cloudfoundry/bosh-cli/director/configs.go#L75) function accepts `limit` as the 1st parameter. When [limit is 1](https://github.com/pivotal-cf/on-demand-service-broker/blob/master/vendor/github.com/cloudfoundry/bosh-cli/director/configs.go#L124), it will return the latest config for each type/name config, otherwise, it will return all config ids for each type/name config.

This commit fixes the `ListConfigs` invokations:
* At [GetConfigs](https://github.com/pivotal-cf/on-demand-service-broker/blob/master/boshdirector/bosh_configs.go#L21) we only need the latest config for each type/name, as no other part of the code needs to deal with the history of configs. Wihout this fix, we will be returning all config ids, and instead of sending the latest config to the service adapter, [we will send the 1st config id](https://github.com/pivotal-cf/on-demand-service-broker/blob/master/task/task.go#L175).
* At [DeleteConfig](https://github.com/pivotal-cf/on-demand-service-broker/blob/master/boshdirector/bosh_configs.go#L68) we only need the list of each type/name config, as we are using the director `DeleteConfig` which will delete all config ids for a particular type/name. Without this fix, we will be making innecessary calls to `DeleteConfig`, as we will be invoking that function for each config id.