### PR TITLE
fix socket leak issue: only one request is allowed at a time for each…

### DIFF
--- a/broker/bind.go
+++ b/broker/bind.go
@@ -27,8 +27,10 @@ func (b *Broker) Bind(
 	details domain.BindDetails,
 	asyncAllowed bool,
 ) (domain.Binding, error) {
-	b.bindLock.Lock()
-	defer b.bindLock.Unlock()
+	if err := b.acquireClusterLock(instanceID); err != nil {
+		return domain.Binding{}, b.processError(err, b.loggerFactory.NewWithContext(ctx))
+	}
+	defer b.releaseClusterLock(instanceID)
 
 	requestID := uuid.New()
 	if len(brokercontext.GetReqID(ctx)) > 0 {

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -8,10 +8,11 @@ package broker
 
 import (
 	"fmt"
-	"github.com/pivotal-cf/on-demand-service-broker/uaa"
 	"log"
 	"strings"
 	"sync"
+
+	"github.com/pivotal-cf/on-demand-service-broker/uaa"
 
 	"github.com/pivotal-cf/on-demand-service-broker/broker/decider"
 
@@ -26,15 +27,15 @@ import (
 )
 
 type Broker struct {
-	boshClient     BoshClient
-	cfClient       CloudFoundryClient
-	adapterClient  ServiceAdapterClient
-	deployer       Deployer
-	secretManager  ManifestSecretManager
-	instanceLister service.InstanceLister
-	hasher         Hasher
-	deploymentLock *sync.Mutex
-	bindLock       *sync.Mutex
+	boshClient      BoshClient
+	cfClient        CloudFoundryClient
+	adapterClient   ServiceAdapterClient
+	deployer        Deployer
+	secretManager   ManifestSecretManager
+	instanceLister  service.InstanceLister
+	hasher          Hasher
+	deploymentLock  *sync.Mutex
+	clusterRegister map[string]struct{}
 
 	serviceOffering           config.ServiceOffering
 	ExposeOperationalErrors   bool
@@ -45,7 +46,6 @@ type Broker struct {
 
 	loggerFactory   *loggerfactory.LoggerFactory
 	telemetryLogger TelemetryLogger
-	catalogLock     sync.Mutex
 	cachedCatalog   []domain.Service
 
 	decider Decider
@@ -74,7 +74,7 @@ func New(
 		adapterClient:             serviceAdapter,
 		deployer:                  deployer,
 		deploymentLock:            &sync.Mutex{},
-		bindLock:                  &sync.Mutex{},
+		clusterRegister:           map[string]struct{}{},
 		serviceOffering:           serviceOffering,
 		ExposeOperationalErrors:   brokerConfig.ExposeOperationalErrors,
 		EnablePlanSchemas:         brokerConfig.EnablePlanSchemas,

--- a/broker/catalog.go
+++ b/broker/catalog.go
@@ -18,9 +18,6 @@ import (
 )
 
 func (b *Broker) Services(ctx context.Context) ([]domain.Service, error) {
-	b.catalogLock.Lock()
-	defer b.catalogLock.Unlock()
-
 	if b.cachedCatalog != nil {
 		return b.cachedCatalog, nil
 	}

--- a/broker/cluster_lock.go
+++ b/broker/cluster_lock.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2016-Present Pivotal Software, Inc. All rights reserved.
+// This program and the accompanying materials are made available under the terms of the under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+package broker
+
+import (
+	"fmt"
+)
+
+// acquireClusterLock acquires the lock for the instance specified by instanceID
+func (b *Broker) acquireClusterLock(instanceID string) error {
+	b.deploymentLock.Lock()
+	defer b.deploymentLock.Unlock()
+
+	if _, ok := b.clusterRegister[instanceID]; ok {
+		return fmt.Errorf("od-broker is processing a request for the instance: %s, please try again later", instanceID)
+	}
+
+	b.clusterRegister[instanceID] = struct{}{}
+	return nil
+}
+
+// releaseClusterLock releases the lock for the instance specified by instanceID
+func (b *Broker) releaseClusterLock(instanceID string) {
+	b.deploymentLock.Lock()
+	defer b.deploymentLock.Unlock()
+
+	delete(b.clusterRegister, instanceID)
+}

--- a/broker/deprovision.go
+++ b/broker/deprovision.go
@@ -27,9 +27,11 @@ func (b *Broker) Deprovision(
 	deprovisionDetails domain.DeprovisionDetails,
 	asyncAllowed bool,
 ) (domain.DeprovisionServiceSpec, error) {
+	if err := b.acquireClusterLock(instanceID); err != nil {
+		return domain.DeprovisionServiceSpec{IsAsync: true}, b.processError(err, b.loggerFactory.NewWithContext(ctx))
+	}
+	defer b.releaseClusterLock(instanceID)
 
-	b.deploymentLock.Lock()
-	defer b.deploymentLock.Unlock()
 	requestID := uuid.New()
 	ctx = brokercontext.New(ctx, string(OperationTypeDelete), requestID, b.serviceOffering.Name, instanceID)
 	logger := b.loggerFactory.NewWithContext(ctx)

--- a/broker/provision.go
+++ b/broker/provision.go
@@ -36,9 +36,10 @@ func (b *Broker) Provision(
 	instanceID string,
 	details domain.ProvisionDetails,
 	asyncAllowed bool) (domain.ProvisionedServiceSpec, error) {
-
-	b.deploymentLock.Lock()
-	defer b.deploymentLock.Unlock()
+	if err := b.acquireClusterLock(instanceID); err != nil {
+		return domain.ProvisionedServiceSpec{}, b.processError(err, b.loggerFactory.NewWithContext(ctx))
+	}
+	defer b.releaseClusterLock(instanceID)
 
 	requestID := uuid.New()
 	ctx = brokercontext.New(ctx, string(OperationTypeCreate), requestID, b.serviceOffering.Name, instanceID)

--- a/broker/unbind.go
+++ b/broker/unbind.go
@@ -22,9 +22,10 @@ func (b *Broker) Unbind(
 	details domain.UnbindDetails,
 	asyncAllowed bool,
 ) (domain.UnbindSpec, error) {
-
-	b.bindLock.Lock()
-	defer b.bindLock.Unlock()
+	if err := b.acquireClusterLock(instanceID); err != nil {
+		return domain.UnbindSpec{}, b.processError(err, b.loggerFactory.NewWithContext(ctx))
+	}
+	defer b.releaseClusterLock(instanceID)
 
 	emptyUnbindSpec := domain.UnbindSpec{}
 	requestID := uuid.New()

--- a/broker/update.go
+++ b/broker/update.go
@@ -85,8 +85,10 @@ func (b *Broker) doUpgrade(ctx context.Context, instanceID string, details domai
 }
 
 func (b *Broker) doUpdate(ctx context.Context, instanceID string, details domain.UpdateDetails, detailsMap map[string]interface{}, contextMap map[string]interface{}, siClient map[string]string, logger *log.Logger) (domain.UpdateServiceSpec, error) {
-	b.deploymentLock.Lock()
-	defer b.deploymentLock.Unlock()
+	if err := b.acquireClusterLock(instanceID); err != nil {
+		return domain.UpdateServiceSpec{}, b.processError(err, logger)
+	}
+	defer b.releaseClusterLock(instanceID)
 
 	plan, err := b.findPlanInCatalog(details, logger)
 	if err != nil {


### PR DESCRIPTION
fix https://github.com/pivotal-cf/on-demand-service-broker/issues/107 

**Currently design & implementation**
Actually this is a generic issue, all operations supported by od-broker are serial operations, even for different clusters. It’s definitely not good.

Provision/Deprovision/Update/Upgrade operations share the same lock. When a user is executing a command creating or deleting or upgrading or updating a cluster, then he/she can't execute another command creating or deleting or updating or upgrading a different cluster before the previous command returns. If a user issues two or more commands at the same time, they will be executed one by one.

Bind (pks get-credentials xxx) operations share a different lock. When a user is executing a “pks get-credentials ”, then he/she can’t execute another “pks get-credentials ” command on a different cluster before the previous one returns.

Normally when the network connectivity is good, then this is not a big issue. But when the network between od-broker and (bosh or api-server) is down or has big latency, then the users may run into the issue described in this ticket.

**The solution**

Users can execute commands (Provision/Deprovision/Update/Upgrade/Bind) against different clusters in parallel;

Commands on the same cluster will be executed one by one. When the od-broker is processing a request for a cluster, If od-broker receives a new request on the same cluster, then it will return an error indicating it’s busy right now, and the user may try again later.