### PR TITLE
test: use nats (vs nats-tls) when cert not set

### DIFF
--- a/system_tests/fixtures/use_nats_without_tls.yml
+++ b/system_tests/fixtures/use_nats_without_tls.yml
@@ -1,0 +1,13 @@
+---
+
+- type: remove
+  path: /instance_groups/name=broker/jobs/name=route_registrar/consumes/nats-tls?
+
+- type: remove
+  path: /instance_groups/name=broker/jobs/name=route_registrar/properties/nats?
+
+- type: replace
+  path: /instance_groups/name=broker/jobs/name=route_registrar/consumes/nats?
+  value:
+    deployment: ((cf.deployment_name))
+    from: nats


### PR DESCRIPTION
On TAS 2.7 there is no nats-tls job (or certificate for that job), so
when we can't see a certificate we should revert to the old behavior of
using nats rather than nats-tls

[#180262739]("https://www.pivotaltracker.com/story/show/180262739")