### PR TITLE
Set redirect_uri when authorization_code grant type

### DIFF
--- a/uaa/client.go
+++ b/uaa/client.go
@@ -91,14 +91,11 @@ func (c *Client) CreateClient(clientID, name, spaceGUID string) (map[string]stri
 	}
 
 	var clientSecret string
-	if strings.Contains(grantTypes, "implicit") {
-		// UAA does not allow `implicit` clients to be created without a redirect uri
+	if strings.Contains(grantTypes, "implicit") || strings.Contains(grantTypes, "authorization_code") {
+		// UAA does not allow `implicit` o `authorization_code` clients to be created without a redirect uri
 		m["redirect_uri"] = placeholderRedirectURI
-	} else {
-		if strings.Contains(grantTypes, "authorization_code") {
-			// UAA does not allow `authorization_code` clients to be created without a redirect uri
-			m["redirect_uri"] = placeholderRedirectURI
-                }
+	}
+	if !strings.Contains(grantTypes, "implicit") {
 		clientSecret = c.RandFunc()
 		m["client_secret"] = clientSecret
 	}

--- a/uaa/client.go
+++ b/uaa/client.go
@@ -95,6 +95,10 @@ func (c *Client) CreateClient(clientID, name, spaceGUID string) (map[string]stri
 		// UAA does not allow `implicit` clients to be created without a redirect uri
 		m["redirect_uri"] = placeholderRedirectURI
 	} else {
+		if strings.Contains(grantTypes, "authorization_code") {
+			// UAA does not allow `authorization_code` clients to be created without a redirect uri
+			m["redirect_uri"] = placeholderRedirectURI
+                }
 		clientSecret = c.RandFunc()
 		m["client_secret"] = clientSecret
 	}


### PR DESCRIPTION
Future versions of RabbitMQ tile will use OAuth2 `authorization_code` flow rather than `implicit` flow for the service's instance UAA client. 
UAA expects both grant types, `implicit` and `authorization_code`, to have a redirec_uri when creating an Oauth2 client. 

This PR is about setting the redirect_uri when using `authorization_code` grant type not only when using `implicit` grant type. Without this change, creating service instance fail because UAA fail to create the oauth2 client for the service instance.
