### PR TITLE
Add run-unit-tests.sh script

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         go-version: ${{ matrix.version }}
     - uses: actions/checkout@v2
-    - run: ./scripts/run-tests.sh --race --fail-on-pending --skip-package=contract_tests,system_tests
+    - run: ./scripts/run-unit-tests.sh
   call-dependabot-pr-workflow:
     needs: test
     if: ${{ success() && github.actor == 'dependabot[bot]' }}

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${script_dir}/run-tests.sh" --race --fail-on-pending --skip-package=contract_tests,system_tests


### PR DESCRIPTION
Updated github configuration to use ./scripts/run-unit-tests.sh rather than directly running "run-test.sh" with exclusion parameters. This makes it easier to run unit-tests identical to how they are run in CI / github-actions.