### PR TITLE
Only run broker tests on latest Go

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '1.19', '1.20' ]
+        version: [stable]
     name: Go ${{ matrix.version }}
     outputs:
       pr_number: ${{ github.event.number }}
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: ./scripts/run-unit-tests.sh
   call-dependabot-pr-workflow:
     needs: test


### PR DESCRIPTION
Current unit test workflows are broken because a dependency of the broker forces a bump to "toolchain go1.21.x" when we use go1.21 in CI.

CI automatically bumps the Go toolchain in
on-demand-service-broker-release to the latest so we definitely want to test with the latest Go version, but we do not necessarily need to support previous Go toolchains.