### PR TITLE
Ensure cf push of the example-service-instances-api app is checked

### DIFF
--- a/system_tests/feature_flags/feature_flags_test.go
+++ b/system_tests/feature_flags/feature_flags_test.go
@@ -81,13 +81,13 @@ var _ = Describe("FeatureFlags", func() {
 			siAPIUsername := "siapi"
 			siAPIPassword := "siapipass"
 
-			cf.Cf("push",
+			Expect(cf.Cf("push",
 				"-p", os.Getenv("SI_API_PATH"),
 				"-f", os.Getenv("SI_API_PATH")+"/manifest.yml",
 				"--var", "app_name="+appName,
 				"--var", "username="+siAPIUsername,
 				"--var", "password="+siAPIPassword,
-			)
+			)).To(gexec.Exit(0), `cf push example-service-instances-api app failed!`)
 
 			brokerInfo = bosh.DeployBroker(
 				"-feature-flag-"+uniqueID,


### PR DESCRIPTION
This failed because the app manifest was hardcoded with GOVERSION=1.21 which was no longer supported by the cloudfoundry environment. Unfortunately the test proceeded anyway and failed later in a way that was harder to troubleshoot.

Now the feature flags tests asserts that cf push actually succeeds - or at least cf push exits non-zero and flags a better error message up-front.